### PR TITLE
Show detailed category and service selection counts

### DIFF
--- a/internal/web/i18n.go
+++ b/internal/web/i18n.go
@@ -47,6 +47,16 @@ var translations = map[locale]map[string]string{
 		"selection.save_failed":      "BGP announcements could not be updated.",
 		"selection.locked":           "Selection is locked by the administrator.",
 		"selection.selected":         "Selected:",
+		"selection.category_one":     "category",
+		"selection.category_few":     "categories",
+		"selection.category_many":    "categories",
+		"selection.service_one":      "service",
+		"selection.service_few":      "services",
+		"selection.service_many":     "services",
+		"selection.in_categories":    "in them",
+		"selection.standalone_one":   "standalone service",
+		"selection.standalone_few":   "standalone services",
+		"selection.standalone_many":  "standalone services",
 		"selection.apply_hint":       "Changes take effect immediately after saving",
 		"selection.save":             "Save routes",
 		"selection.whole_category":   "all",
@@ -131,6 +141,16 @@ var translations = map[locale]map[string]string{
 		"selection.save_failed":      "Не удалось обновить BGP-анонсы.",
 		"selection.locked":           "Выбор заблокирован администратором.",
 		"selection.selected":         "Выбрано:",
+		"selection.category_one":     "категория",
+		"selection.category_few":     "категории",
+		"selection.category_many":    "категорий",
+		"selection.service_one":      "сервис",
+		"selection.service_few":      "сервиса",
+		"selection.service_many":     "сервисов",
+		"selection.in_categories":    "в них",
+		"selection.standalone_one":   "отдельный сервис",
+		"selection.standalone_few":   "отдельных сервиса",
+		"selection.standalone_many":  "отдельных сервисов",
 		"selection.apply_hint":       "Изменения применяются сразу после сохранения",
 		"selection.save":             "Сохранить маршруты",
 		"selection.whole_category":   "целиком",
@@ -203,6 +223,22 @@ func translate(lang locale, key string) string {
 		return message
 	}
 	return key
+}
+
+func pluralTranslation(lang locale, count int, oneKey, fewKey, manyKey string) string {
+	key := manyKey
+	if lang == localeRussian {
+		mod10 := count % 10
+		mod100 := count % 100
+		if mod10 == 1 && mod100 != 11 {
+			key = oneKey
+		} else if mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14) {
+			key = fewKey
+		}
+	} else if count == 1 {
+		key = oneKey
+	}
+	return translate(lang, key)
 }
 
 func requestLocale(r *http.Request, fallback locale) (locale, bool) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -53,13 +53,15 @@ type serviceView struct {
 }
 
 type selectionView struct {
-	User          store.User
-	Categories    []categoryView
-	Editable      bool
-	Admin         bool
-	Saved         string
-	Filters       filterView
-	SelectedCount int
+	User                    store.User
+	Categories              []categoryView
+	Editable                bool
+	Admin                   bool
+	Saved                   string
+	Filters                 filterView
+	SelectedCategoryCount   int
+	SelectedCoveredServices int
+	SelectedServiceCount    int
 }
 
 type adminView struct {
@@ -515,19 +517,12 @@ func (s *Server) selection(ctx context.Context, user store.User, editable, admin
 		names = append(names, name)
 	}
 	sortStrings(names)
-	selectedCount := len(selectedCategories)
-	for service := range selectedServices {
-		if !selectedCategories[service.Category] {
-			selectedCount++
-		}
-	}
 	userFilters, err := s.store.UserRouteFilters(ctx, user.ID)
 	if err != nil {
 		return selectionView{}, err
 	}
 	view := selectionView{
 		User: user, Editable: editable, Admin: admin,
-		SelectedCount: selectedCount,
 		Filters: filterView{
 			AllowText: strings.Join(userFilters.Allow, "\n"),
 			DenyText:  strings.Join(userFilters.Deny, "\n"),
@@ -540,8 +535,15 @@ func (s *Server) selection(ctx context.Context, user store.User, editable, admin
 	for _, category := range names {
 		categorySelected := selectedCategories[category]
 		item := categoryView{Name: category, Selected: categorySelected}
+		if categorySelected {
+			view.SelectedCategoryCount++
+			view.SelectedCoveredServices += len(catalog[category])
+		}
 		for _, service := range catalog[category] {
 			key := store.ServiceKey{Category: category, Service: service}
+			if !categorySelected && selectedServices[key] {
+				view.SelectedServiceCount++
+			}
 			item.Services = append(item.Services, serviceView{
 				Name: service, Value: serviceValue(category, service),
 				Selected: !categorySelected && selectedServices[key],
@@ -701,6 +703,9 @@ func compileTemplates() map[locale]map[string]*template.Template {
 				},
 				"tr": func(key string) string {
 					return translate(lang, key)
+				},
+				"plural": func(count int, oneKey, fewKey, manyKey string) string {
+					return pluralTranslation(lang, count, oneKey, fewKey, manyKey)
 				},
 			}
 			result[lang][name] = template.Must(template.New("page").Funcs(funcs).

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -198,12 +198,13 @@ func TestCategorySelectionDisablesContainedServices(t *testing.T) {
 	}
 	if _, err := db.DB.Exec(`INSERT INTO catalog_entries(feed_id, category, service, cidr) VALUES
 		(1, 'Messengers', 'Telegram', '149.154.160.0/20'),
-		(1, 'Messengers', 'Signal', '76.223.92.0/24')`); err != nil {
+		(1, 'Messengers', 'Signal', '76.223.92.0/24'),
+		(1, 'AI', 'Copilot', '140.82.112.0/20')`); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.Transaction(context.Background(), func(tx *sql.Tx) error {
 		return store.SetUserSelection(context.Background(), tx, userID, []string{"Messengers"},
-			[]store.ServiceKey{{Category: "Messengers", Service: "Telegram"}})
+			[]store.ServiceKey{{Category: "AI", Service: "Copilot"}})
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -217,8 +218,17 @@ func TestCategorySelectionDisablesContainedServices(t *testing.T) {
 	if response.Code != http.StatusOK {
 		t.Fatalf("user page status=%d body=%s", response.Code, body)
 	}
-	if !strings.Contains(body, "Выбрано: <span id=selected-count>1</span>") {
-		t.Fatalf("selected count not rendered: %s", body)
+	for _, want := range []string{
+		`<span id=selected-category-count>1</span>`,
+		`>категория</span>`,
+		`<span id=selected-covered-service-count>2</span>`,
+		`>сервиса</span> в них`,
+		`<span id=selected-service-count>1</span>`,
+		`>отдельный сервис</span>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("selection details %q not rendered: %s", want, body)
+		}
 	}
 	if !strings.Contains(body, `value="Messengers:Telegram"  disabled`) {
 		t.Fatalf("contained selected service is not disabled: %s", body)
@@ -553,6 +563,30 @@ func TestTranslationCatalogsHaveMatchingKeys(t *testing.T) {
 	}
 	if got := translate(localeEnglish, "missing.key"); got != "missing.key" {
 		t.Fatalf("missing translation = %q, want key", got)
+	}
+}
+
+func TestSelectionPluralTranslations(t *testing.T) {
+	tests := []struct {
+		lang  locale
+		count int
+		want  string
+	}{
+		{localeEnglish, 1, "category"},
+		{localeEnglish, 2, "categories"},
+		{localeRussian, 1, "категория"},
+		{localeRussian, 2, "категории"},
+		{localeRussian, 5, "категорий"},
+		{localeRussian, 11, "категорий"},
+		{localeRussian, 22, "категории"},
+	}
+	for _, test := range tests {
+		got := pluralTranslation(test.lang, test.count,
+			"selection.category_one", "selection.category_few", "selection.category_many")
+		if got != test.want {
+			t.Errorf("pluralTranslation(%q, %d) = %q, want %q",
+				test.lang, test.count, got, test.want)
+		}
 	}
 }
 

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -41,13 +41,57 @@ const selectionBody = `{{$selection := .}}
 {{if not .Editable}}<p class=muted>{{tr "selection.locked"}}</p>{{end}}
 <form class=selection-form method=post action="{{if .Admin}}/admin/user/{{.User.ID}}{{else}}/selection{{end}}">
 {{if .Admin}}<input type=hidden name=action value=selection>{{end}}
-<div class=save-bar><div><strong>{{.User.Name}}</strong><br><span class=muted>{{tr "selection.selected"}} <span id=selected-count>{{.SelectedCount}}</span>. {{tr "selection.apply_hint"}}</span></div>
+<div class=save-bar><div><strong>{{.User.Name}}</strong><br><span class=muted>{{tr "selection.selected"}}
+<span id=selected-category-count>{{.SelectedCategoryCount}}</span>
+<span id=selected-category-label data-one="{{tr "selection.category_one"}}" data-few="{{tr "selection.category_few"}}" data-many="{{tr "selection.category_many"}}">{{plural .SelectedCategoryCount "selection.category_one" "selection.category_few" "selection.category_many"}}</span>
+(<span id=selected-covered-service-count>{{.SelectedCoveredServices}}</span>
+<span id=selected-covered-service-label data-one="{{tr "selection.service_one"}}" data-few="{{tr "selection.service_few"}}" data-many="{{tr "selection.service_many"}}">{{plural .SelectedCoveredServices "selection.service_one" "selection.service_few" "selection.service_many"}}</span> {{tr "selection.in_categories"}}).
+<span id=selected-service-count>{{.SelectedServiceCount}}</span>
+<span id=selected-service-label data-one="{{tr "selection.standalone_one"}}" data-few="{{tr "selection.standalone_few"}}" data-many="{{tr "selection.standalone_many"}}">{{plural .SelectedServiceCount "selection.standalone_one" "selection.standalone_few" "selection.standalone_many"}}</span>.
+{{tr "selection.apply_hint"}}</span></div>
 <button {{if not .Editable}}disabled{{end}}>{{tr "selection.save"}}</button></div>
 {{if .Categories}}<div class=catalog-grid>{{range .Categories}}
 <fieldset class=category-card><legend><label class=category-title><input type=checkbox name=category value="{{.Name}}" {{if .Selected}}checked{{end}} {{if not $selection.Editable}}disabled{{end}}> <strong>{{.Name}}</strong> <span class=pill>{{tr "selection.whole_category"}}</span></label></legend>
 <div class=service-list>{{range .Services}}<label><input type=checkbox name=service value="{{.Value}}" {{if .Selected}}checked{{end}} {{if or (not $selection.Editable) .Disabled}}disabled{{end}}> {{.Name}}</label>{{end}}</div>
 </fieldset>{{end}}</div>{{else}}<p class=empty>{{tr "selection.empty"}}</p>{{end}}</form></section>
 <script>
+function selectionPluralForm(count) {
+  if (document.documentElement.lang !== 'ru') {
+    return count === 1 ? 'one' : 'many';
+  }
+  var mod10 = count % 10;
+  var mod100 = count % 100;
+  if (mod10 === 1 && mod100 !== 11) return 'one';
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return 'few';
+  return 'many';
+}
+function updateSelectionLabel(id, count) {
+  var label = document.getElementById(id);
+  if (label) label.textContent = label.dataset[selectionPluralForm(count)];
+}
+function updateSelectionCounts() {
+  var categoryCount = 0;
+  var coveredServiceCount = 0;
+  var standaloneServiceCount = 0;
+  document.querySelectorAll('fieldset.category-card').forEach(function(fieldset) {
+    var categoryInput = fieldset.querySelector('input[name="category"]');
+    var services = fieldset.querySelectorAll('input[name="service"]');
+    if (categoryInput && categoryInput.checked) {
+      categoryCount++;
+      coveredServiceCount += services.length;
+    } else {
+      services.forEach(function(serviceInput) {
+        if (serviceInput.checked) standaloneServiceCount++;
+      });
+    }
+  });
+  document.getElementById('selected-category-count').textContent = categoryCount;
+  document.getElementById('selected-covered-service-count').textContent = coveredServiceCount;
+  document.getElementById('selected-service-count').textContent = standaloneServiceCount;
+  updateSelectionLabel('selected-category-label', categoryCount);
+  updateSelectionLabel('selected-covered-service-label', coveredServiceCount);
+  updateSelectionLabel('selected-service-label', standaloneServiceCount);
+}
 document.querySelectorAll('input[name="category"]').forEach(function(categoryInput) {
   var fieldset = categoryInput.closest('fieldset');
   var services = fieldset ? fieldset.querySelectorAll('input[name="service"]') : [];
@@ -55,15 +99,13 @@ document.querySelectorAll('input[name="category"]').forEach(function(categoryInp
     services.forEach(function(serviceInput) {
       serviceInput.disabled = categoryInput.checked || categoryInput.disabled;
     });
-    var count = document.getElementById('selected-count');
-    if (count) {
-      count.textContent = document.querySelectorAll('input[name="category"]:checked,input[name="service"]:checked:not(:disabled)').length;
-    }
+    updateSelectionCounts();
   };
   categoryInput.addEventListener('change', update);
   services.forEach(function(serviceInput) { serviceInput.addEventListener('change', update); });
   update();
 });
+updateSelectionCounts();
 </script>
 {{with .Filters}}<section class=card><h2>{{tr "filters.heading"}}</h2>
 {{if .Editable}}<p class=muted>{{tr "filters.explanation"}}</p>


### PR DESCRIPTION
## Summary
- replace the ambiguous total selection count with separate category and standalone service counts
- show how many visible services are covered by selected whole categories
- update all three values live when category or service checkboxes change
- add correct English and Russian plural forms
- render the complete count text server-side before JavaScript runs

Example: `Выбрано: 2 категории (15 сервисов в них). 3 отдельных сервиса.`

## Tests
- `go test ./...`
- `go vet ./...`
- `git diff --check`