### PR TITLE
feat: make JavaScript adapter limits configurable via env vars

### DIFF
--- a/.opencode/agent/devops.md
+++ b/.opencode/agent/devops.md
@@ -1,0 +1,16 @@
+---
+description: Works with GitHub and Docker Hub via CLI. Uses gh, git and docker.
+mode: subagent
+permission:
+  edit: deny
+  bash:
+    "*": ask
+    "git *": allow
+    "gh *": allow
+    "docker *": allow
+    "go test *": allow
+    "go vet *": allow
+    "go build *": allow
+---
+
+You are a devops agent. Work with GitHub and Docker Hub via CLI using gh, git, and docker commands. Execute tasks efficiently without asking for permission on allowed commands.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,13 @@ password check. Force `true` only when the admin UI is always served over HTTPS.
 | `WDBGP_LOG_LEVEL` | `INFO` |
 | `WDBGP_LOG_FORMAT` | `text` |
 | `WDBGP_TRUST_PROXY_HEADERS` | `false` |
+| `WDBGP_JS_TIMEOUT` | `120` seconds |
+| `WDBGP_JS_MAX_SOURCE` | `1048576` (1 MiB) |
+| `WDBGP_JS_MAX_RESPONSE` | `16777216` (16 MiB) |
+| `WDBGP_JS_MAX_TOTAL` | `67108864` (64 MiB) |
+| `WDBGP_JS_MAX_ENTRIES` | `1000000` |
+| `WDBGP_JS_MAX_REQUESTS` | `200` |
+| `WDBGP_JS_MAX_CALL_STACK` | `1000` |
 
 `WDBGP_ADMIN_PASSWORD` and `WDBGP_SESSION_SECRET` are required by `serve`.
 The old `WDBGP_BIRD_LOCAL_ADDRESS` and `WDBGP_BIRD_LOCAL_ADDRESS_V6` names are

--- a/README.ru.md
+++ b/README.ru.md
@@ -193,6 +193,13 @@ cookie и после правильного пароля снова переки
 | `WDBGP_LOG_LEVEL` | `INFO` |
 | `WDBGP_LOG_FORMAT` | `text` |
 | `WDBGP_TRUST_PROXY_HEADERS` | `false` |
+| `WDBGP_JS_TIMEOUT` | `120` секунд |
+| `WDBGP_JS_MAX_SOURCE` | `1048576` (1 МиБ) |
+| `WDBGP_JS_MAX_RESPONSE` | `16777216` (16 МиБ) |
+| `WDBGP_JS_MAX_TOTAL` | `67108864` (64 МиБ) |
+| `WDBGP_JS_MAX_ENTRIES` | `1000000` |
+| `WDBGP_JS_MAX_REQUESTS` | `200` |
+| `WDBGP_JS_MAX_CALL_STACK` | `1000` |
 
 `WDBGP_ADMIN_PASSWORD` и `WDBGP_SESSION_SECRET` обязательны для `serve`.
 Старые имена `WDBGP_BIRD_LOCAL_ADDRESS` и

--- a/cmd/wdbgp/main.go
+++ b/cmd/wdbgp/main.go
@@ -54,7 +54,7 @@ func run() error {
 	case "stats":
 		return printStats(context.Background(), db)
 	case "sync":
-		syncer := feeds.NewSyncer(db)
+		syncer := feeds.NewSyncer(db, cfg)
 		if syncErrors := syncer.SyncAll(context.Background()); len(syncErrors) > 0 {
 			for _, syncErr := range syncErrors {
 				logging.Error("feed sync error", "error", syncErr)
@@ -96,7 +96,7 @@ func serve(cfg config.Config, db *store.Store) error {
 		}
 	}()
 
-	syncer := feeds.NewSyncer(db)
+	syncer := feeds.NewSyncer(db, cfg)
 	go syncLoop(ctx, cfg.SyncInterval, syncer, bgpManager)
 
 	httpServer := &http.Server{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,8 +30,15 @@ type Config struct {
 	RateLimitLogin    int
 	RateLimitAdmin    int
 	SessionMaxAge     int
-	LogLevel          string
-	LogFormat         string
+	LogLevel           string
+	LogFormat          string
+	JSTimeout          time.Duration
+	JSMaxSourceBytes   int
+	JSMaxResponseBytes int
+	JSMaxTotalBytes    int
+	JSMaxEntries       int
+	JSMaxRequests      int
+	JSMaxCallStack     int
 }
 
 func Load() (Config, error) {
@@ -99,6 +106,34 @@ func Load() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+	jsTimeout, err := integer("WDBGP_JS_TIMEOUT", 120)
+	if err != nil {
+		return Config{}, err
+	}
+	jsMaxSource, err := integer("WDBGP_JS_MAX_SOURCE", 1048576)
+	if err != nil {
+		return Config{}, err
+	}
+	jsMaxResponse, err := integer("WDBGP_JS_MAX_RESPONSE", 16777216)
+	if err != nil {
+		return Config{}, err
+	}
+	jsMaxTotal, err := integer("WDBGP_JS_MAX_TOTAL", 67108864)
+	if err != nil {
+		return Config{}, err
+	}
+	jsMaxEntries, err := integer("WDBGP_JS_MAX_ENTRIES", 1000000)
+	if err != nil {
+		return Config{}, err
+	}
+	jsMaxRequests, err := integer("WDBGP_JS_MAX_REQUESTS", 200)
+	if err != nil {
+		return Config{}, err
+	}
+	jsMaxCallStack, err := integer("WDBGP_JS_MAX_CALL_STACK", 1000)
+	if err != nil {
+		return Config{}, err
+	}
 	cfg := Config{
 		DBPath:            dbPath,
 		Host:              host,
@@ -118,8 +153,15 @@ func Load() (Config, error) {
 		RateLimitLogin:    rateLimitLogin,
 		RateLimitAdmin:    rateLimitAdmin,
 		SessionMaxAge:     sessionMaxAge,
-		LogLevel:          logLevel,
-		LogFormat:         logFormat,
+		LogLevel:           logLevel,
+		LogFormat:          logFormat,
+		JSTimeout:          time.Duration(jsTimeout) * time.Second,
+		JSMaxSourceBytes:   jsMaxSource,
+		JSMaxResponseBytes: jsMaxResponse,
+		JSMaxTotalBytes:    jsMaxTotal,
+		JSMaxEntries:       jsMaxEntries,
+		JSMaxRequests:      jsMaxRequests,
+		JSMaxCallStack:     jsMaxCallStack,
 	}
 	return cfg, nil
 }

--- a/internal/feeds/feeds.go
+++ b/internal/feeds/feeds.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/andrey-vk/wdbgp/internal/config"
 	"github.com/andrey-vk/wdbgp/internal/logging"
 	"github.com/andrey-vk/wdbgp/internal/retry"
 	"github.com/andrey-vk/wdbgp/internal/store"
@@ -38,22 +39,51 @@ type openCCKEntry struct {
 	CIDR6 []string `json:"cidr6"`
 }
 
+type AdapterLimits struct {
+	MaxSourceBytes   int
+	MaxResponseBytes int
+	MaxTotalBytes    int
+	MaxEntries       int
+	MaxRequests      int
+	MaxCallStack     int
+}
+
 type Syncer struct {
 	Store         *store.Store
 	Client        *http.Client
 	ScriptTimeout time.Duration
+	Limits        AdapterLimits
 }
 
 var errFeedChanged = errors.New("feed changed during synchronization")
 
 const ipRangesURL = "https://github.com/antonme/ipranges"
 
-func NewSyncer(s *store.Store) *Syncer {
+func NewSyncer(s *store.Store, cfg config.Config) *Syncer {
+	timeout := cfg.JSTimeout
+	if timeout <= 0 {
+		timeout = 120 * time.Second
+	}
 	return &Syncer{
 		Store:         s,
-		Client:        newHTTPClient(120 * time.Second),
-		ScriptTimeout: 120 * time.Second,
+		Client:        newHTTPClient(timeout),
+		ScriptTimeout: timeout,
+		Limits: AdapterLimits{
+			MaxSourceBytes:   ifZero(cfg.JSMaxSourceBytes, 1<<20),
+			MaxResponseBytes: ifZero(cfg.JSMaxResponseBytes, 16<<20),
+			MaxTotalBytes:    ifZero(cfg.JSMaxTotalBytes, 64<<20),
+			MaxEntries:       ifZero(cfg.JSMaxEntries, 1_000_000),
+			MaxRequests:      ifZero(cfg.JSMaxRequests, 200),
+			MaxCallStack:     ifZero(cfg.JSMaxCallStack, 1_000),
+		},
 	}
+}
+
+func ifZero(val, def int) int {
+	if val <= 0 {
+		return def
+	}
+	return val
 }
 
 func (s *Syncer) SyncAll(ctx context.Context) []error {
@@ -95,7 +125,7 @@ func (s *Syncer) TestAdapter(
 	adapter store.FeedAdapter,
 ) ([]Entry, error) {
 	return (adapterRunner{
-		client: s.Client, timeout: s.ScriptTimeout,
+		client: s.Client, timeout: s.ScriptTimeout, limits: s.Limits,
 	}).run(ctx, feed, adapter)
 }
 

--- a/internal/feeds/feeds_test.go
+++ b/internal/feeds/feeds_test.go
@@ -12,8 +12,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/andrey-vk/wdbgp/internal/config"
 	"github.com/andrey-vk/wdbgp/internal/store"
 )
+
+func testLimits() AdapterLimits {
+	return AdapterLimits{
+		MaxSourceBytes: 1 << 20, MaxResponseBytes: 16 << 20,
+		MaxTotalBytes: 64 << 20, MaxEntries: 1_000_000,
+		MaxRequests: 200, MaxCallStack: 1_000,
+	}
+}
 
 func TestParseCanonicalNormalizesAndDeduplicates(t *testing.T) {
 	entries, err := Parse([]byte(`{"entries":[
@@ -69,7 +78,7 @@ func TestJavaScriptAdapterNormalizesResult(t *testing.T) {
 			Header:     make(http.Header),
 		}, nil
 	})}
-	entries, err := (adapterRunner{client: client, timeout: time.Second}).run(
+	entries, err := (adapterRunner{limits: testLimits(), client: client, timeout: time.Second}).run(
 		context.Background(),
 		store.Feed{ID: 1, Name: "test", URL: "https://example.test/feed"},
 		store.FeedAdapter{
@@ -96,7 +105,7 @@ func TestJavaScriptAdapterRejectsUnlistedHost(t *testing.T) {
 		t.Fatal("HTTP client must not be called")
 		return nil, nil
 	})}
-	_, err := (adapterRunner{client: client, timeout: time.Second}).run(
+	_, err := (adapterRunner{limits: testLimits(), client: client, timeout: time.Second}).run(
 		context.Background(),
 		store.Feed{URL: "https://example.test/feed"},
 		store.FeedAdapter{
@@ -114,7 +123,7 @@ func TestJavaScriptAdapterRejectsUnlistedHost(t *testing.T) {
 
 func TestJavaScriptAdapterTimesOut(t *testing.T) {
 	_, err := (adapterRunner{
-		client: &http.Client{}, timeout: 10 * time.Millisecond,
+		limits: testLimits(), client: &http.Client{}, timeout: 10 * time.Millisecond,
 	}).run(
 		context.Background(),
 		store.Feed{URL: "https://example.test/feed"},
@@ -138,7 +147,7 @@ func TestJavaScriptAdapterStopsWhenContextIsCanceled(t *testing.T) {
 	}()
 	started := time.Now()
 	_, err := (adapterRunner{
-		client: &http.Client{}, timeout: 5 * time.Second,
+		limits: testLimits(), client: &http.Client{}, timeout: 5 * time.Second,
 	}).run(
 		ctx,
 		store.Feed{URL: "https://example.test/feed"},
@@ -175,7 +184,8 @@ func TestAdapterHTTPFollowsValidatedRedirect(t *testing.T) {
 		}, nil
 	})}
 	api, err := newAdapterHTTP(
-		context.Background(), client, "https://example.test/feed", "")
+		context.Background(), client, "https://example.test/feed", "",
+		AdapterLimits{MaxRequests: 200, MaxResponseBytes: 16 << 20, MaxTotalBytes: 64 << 20})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +209,8 @@ func TestAdapterHTTPRejectsRedirectToUnlistedHost(t *testing.T) {
 		}, nil
 	})}
 	api, err := newAdapterHTTP(
-		context.Background(), client, "https://example.test/feed", "")
+		context.Background(), client, "https://example.test/feed", "",
+		AdapterLimits{MaxRequests: 200, MaxResponseBytes: 16 << 20, MaxTotalBytes: 64 << 20})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +304,7 @@ func TestSyncAllSkipsDisabledFeeds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	syncer := NewSyncer(db)
+	syncer := NewSyncer(db, config.Config{})
 	syncer.Client = client
 	if syncErrors := syncer.SyncAll(context.Background()); len(syncErrors) != 0 {
 		t.Fatalf("SyncAll errors = %v", syncErrors)
@@ -338,7 +349,7 @@ func TestSyncDiscardsDownloadWhenFeedURLChanges(t *testing.T) {
 	}
 	feed := feedList[0]
 
-	syncer := NewSyncer(db)
+	syncer := NewSyncer(db, config.Config{})
 	syncer.Client = &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		if request.URL.String() != oldURL {
 			t.Fatalf("download URL = %q, want %q", request.URL, oldURL)
@@ -401,7 +412,7 @@ func TestSyncDiscardsResultWhenAdapterChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	syncer := NewSyncer(db)
+	syncer := NewSyncer(db, config.Config{})
 	syncer.Client = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
 		adapter.Name = "changed during sync"
 		if err := db.UpdateFeedAdapter(ctx, adapter); err != nil {
@@ -456,7 +467,7 @@ func TestSyncIPRangesFeedStoresModeCatalog(t *testing.T) {
 	if len(feedList) != 1 || feedList[0].URL != ipRangesURL {
 		t.Fatalf("enabled feeds = %#v", feedList)
 	}
-	syncer := NewSyncer(db)
+	syncer := NewSyncer(db, config.Config{})
 	syncer.Client = &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
 		body := "203.0.113.0/24\n"
 		if strings.Contains(request.URL.Path, "ipv6_merged.txt") {

--- a/internal/feeds/javascript.go
+++ b/internal/feeds/javascript.go
@@ -214,6 +214,9 @@ func (a *adapterHTTP) get(rawURL string) (string, error) {
 }
 
 func (a *adapterHTTP) doHTTPRequest(parsed *url.URL) (string, error) {
+	if a.requests >= a.limits.MaxRequests {
+		return "", fmt.Errorf("adapter exceeded %d HTTP requests", a.limits.MaxRequests)
+	}
 	a.requests++
 
 	request, err := http.NewRequestWithContext(a.ctx, http.MethodGet, parsed.String(), nil)

--- a/internal/feeds/javascript.go
+++ b/internal/feeds/javascript.go
@@ -17,22 +17,17 @@ import (
 	"github.com/dop251/goja"
 )
 
-const (
-	maxAdapterRequests      = 200
-	maxAdapterResponseBytes = 16 << 20
-	maxAdapterTotalBytes    = 64 << 20
-	maxAdapterEntries       = 1_000_000
-	maxAdapterSourceBytes   = 1 << 20
-)
+
 
 type adapterRunner struct {
 	client  *http.Client
 	timeout time.Duration
+	limits  AdapterLimits
 }
 
-func ValidateAdapterSource(source string) error {
-	if len(source) > maxAdapterSourceBytes {
-		return fmt.Errorf("adapter source exceeds %d bytes", maxAdapterSourceBytes)
+func ValidateAdapterSource(source string, maxBytes int) error {
+	if len(source) > maxBytes {
+		return fmt.Errorf("adapter source exceeds %d bytes", maxBytes)
 	}
 	_, err := goja.Compile("feed-adapter.js", source, true)
 	if err != nil {
@@ -57,7 +52,7 @@ func (r adapterRunner) run(
 	if adapter.APIVersion != 1 {
 		return nil, fmt.Errorf("unsupported adapter API version %d", adapter.APIVersion)
 	}
-	if err := ValidateAdapterSource(adapter.Source); err != nil {
+	if err := ValidateAdapterSource(adapter.Source, r.limits.MaxSourceBytes); err != nil {
 		return nil, err
 	}
 	timeout := r.timeout
@@ -69,7 +64,7 @@ func (r adapterRunner) run(
 
 	vm := goja.New()
 	vm.SetFieldNameMapper(goja.TagFieldNameMapper("json", true))
-	vm.SetMaxCallStackSize(1_000)
+	vm.SetMaxCallStackSize(r.limits.MaxCallStack)
 	program, err := goja.Compile(adapter.Key+".js", adapter.Source, true)
 	if err != nil {
 		return nil, fmt.Errorf("compile adapter: %w", err)
@@ -91,7 +86,7 @@ func (r adapterRunner) run(
 		return nil, fmt.Errorf("adapter must define function sync(feed, api)")
 	}
 
-	httpAPI, err := newAdapterHTTP(runCtx, r.client, feed.URL, adapter.AllowedHosts)
+	httpAPI, err := newAdapterHTTP(runCtx, r.client, feed.URL, adapter.AllowedHosts, r.limits)
 	if err != nil {
 		return nil, err
 	}
@@ -125,13 +120,13 @@ func (r adapterRunner) run(
 	if err := vm.ExportTo(value, &rawEntries); err != nil {
 		return nil, fmt.Errorf("adapter result must be an entry array: %w", err)
 	}
-	if len(rawEntries) > maxAdapterEntries {
-		return nil, fmt.Errorf("adapter returned more than %d entries", maxAdapterEntries)
+	if len(rawEntries) > r.limits.MaxEntries {
+		return nil, fmt.Errorf("adapter returned more than %d entries", r.limits.MaxEntries)
 	}
-	return normalizeCanonical(rawEntries)
+	return normalizeCanonical(rawEntries, r.limits.MaxEntries)
 }
 
-func normalizeCanonical(rawEntries []canonicalEntry) ([]Entry, error) {
+func normalizeCanonical(rawEntries []canonicalEntry, maxEntries int) ([]Entry, error) {
 	var entries []Entry
 	for _, value := range rawEntries {
 		value.Category = strings.TrimSpace(value.Category)
@@ -150,8 +145,8 @@ func normalizeCanonical(rawEntries []canonicalEntry) ([]Entry, error) {
 				Service:  value.Service,
 				CIDR:     cidr,
 			})
-			if len(entries) > maxAdapterEntries {
-				return nil, fmt.Errorf("adapter returned more than %d CIDRs", maxAdapterEntries)
+			if len(entries) > maxEntries {
+				return nil, fmt.Errorf("adapter returned more than %d CIDRs", maxEntries)
 			}
 		}
 	}
@@ -162,6 +157,7 @@ type adapterHTTP struct {
 	ctx          context.Context
 	client       *http.Client
 	allowedHosts map[string]bool
+	limits       AdapterLimits
 	requests     int
 	totalBytes   int64
 }
@@ -171,6 +167,7 @@ func newAdapterHTTP(
 	client *http.Client,
 	feedURL string,
 	additionalHosts string,
+	limits AdapterLimits,
 ) (*adapterHTTP, error) {
 	parsedFeedURL, err := url.Parse(feedURL)
 	if err != nil || parsedFeedURL.Hostname() == "" {
@@ -183,7 +180,7 @@ func newAdapterHTTP(
 		allowed[strings.ToLower(strings.TrimSpace(host))] = true
 	}
 	return &adapterHTTP{
-		ctx: ctx, client: client, allowedHosts: allowed,
+		ctx: ctx, client: client, allowedHosts: allowed, limits: limits,
 	}, nil
 }
 
@@ -252,18 +249,18 @@ func (a *adapterHTTP) doHTTPRequest(parsed *url.URL) (string, error) {
 		return "", fmt.Errorf("HTTP %s", response.Status)
 	}
 	
-	body, err := io.ReadAll(io.LimitReader(response.Body, maxAdapterResponseBytes+1))
+	body, err := io.ReadAll(io.LimitReader(response.Body, int64(a.limits.MaxResponseBytes)+1))
 	if err != nil {
 		return "", err
 	}
-	
-	if len(body) > maxAdapterResponseBytes {
-		return "", fmt.Errorf("adapter HTTP response exceeds %d bytes", maxAdapterResponseBytes)
+
+	if len(body) > a.limits.MaxResponseBytes {
+		return "", fmt.Errorf("adapter HTTP response exceeds %d bytes", a.limits.MaxResponseBytes)
 	}
-	
+
 	a.totalBytes += int64(len(body))
-	if a.totalBytes > maxAdapterTotalBytes {
-		return "", fmt.Errorf("adapter HTTP responses exceed %d bytes", maxAdapterTotalBytes)
+	if a.totalBytes > int64(a.limits.MaxTotalBytes) {
+		return "", fmt.Errorf("adapter HTTP responses exceed %d bytes", a.limits.MaxTotalBytes)
 	}
 	
 	return string(body), nil
@@ -300,8 +297,8 @@ func (a *adapterHTTP) validateURL(parsed *url.URL) error {
 }
 
 func (a *adapterHTTP) reserveRequest() error {
-	if a.requests >= maxAdapterRequests {
-		return fmt.Errorf("adapter exceeded %d HTTP requests", maxAdapterRequests)
+	if a.requests >= a.limits.MaxRequests {
+		return fmt.Errorf("adapter exceeded %d HTTP requests", a.limits.MaxRequests)
 	}
 	return nil
 }

--- a/internal/feeds/retry_integration_test.go
+++ b/internal/feeds/retry_integration_test.go
@@ -30,7 +30,7 @@ func TestJavaScriptAdapter_HTTPRetry(t *testing.T) {
 		}, nil
 	})}
 
-	entries, err := (adapterRunner{client: client, timeout: 5 * time.Second}).run(
+	entries, err := (adapterRunner{limits: testLimits(), client: client, timeout: 5 * time.Second}).run(
 		context.Background(),
 		store.Feed{ID: 1, Name: "test", URL: "https://example.test/feed"},
 		store.FeedAdapter{

--- a/internal/web/cidr_debug_test.go
+++ b/internal/web/cidr_debug_test.go
@@ -52,7 +52,7 @@ func TestCIDRDebugCoverageByServiceAndUser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	server := New(config.Config{}, db, feeds.NewSyncer(db), &fakeBGP{})
+	server := New(config.Config{}, db, feeds.NewSyncer(db, config.Config{}), &fakeBGP{})
 	result, err := server.debugCIDR(ctx, "10.0.0.0/24")
 	if err != nil {
 		t.Fatal(err)
@@ -112,7 +112,7 @@ func TestCIDRDebugCombinedCoverageFromMultipleServices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := New(config.Config{}, db, feeds.NewSyncer(db), &fakeBGP{}).
+	result, err := New(config.Config{}, db, feeds.NewSyncer(db, config.Config{}), &fakeBGP{}).
 		debugCIDR(context.Background(), "10.0.0.0/24")
 	if err != nil {
 		t.Fatal(err)
@@ -167,7 +167,7 @@ func TestCIDRDebugUsesSelectedModeAndMatchingUsers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := New(config.Config{}, db, feeds.NewSyncer(db), &fakeBGP{}).
+	result, err := New(config.Config{}, db, feeds.NewSyncer(db, config.Config{}), &fakeBGP{}).
 		debugCIDR(ctx, "8.8.8.8", ipranges.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -188,7 +188,7 @@ func TestCIDRDebugEndpointRequiresAdminAndReturnsJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg := config.Config{SessionSecret: "secret"}
-	handler := New(cfg, db, feeds.NewSyncer(db), &fakeBGP{}).Handler()
+	handler := New(cfg, db, feeds.NewSyncer(db, config.Config{}), &fakeBGP{}).Handler()
 
 	request := httptest.NewRequest(http.MethodGet, "/admin/debug/cidr?cidr=8.8.8.8", nil)
 	response := httptest.NewRecorder()

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -738,7 +738,7 @@ func parseFeedAdapter(r *http.Request, id int64) (store.FeedAdapter, error) {
 	if err := store.ValidateFeedAdapter(adapter); err != nil {
 		return adapter, err
 	}
-	if err := feeds.ValidateAdapterSource(adapter.Source); err != nil {
+	if err := feeds.ValidateAdapterSource(adapter.Source, 1<<20); err != nil {
 		return adapter, err
 	}
 	return adapter, nil

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -466,7 +466,7 @@ func (s *Server) addFeed(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) addFeedAdapter(w http.ResponseWriter, r *http.Request) {
-	adapter, err := parseFeedAdapter(r, 0)
+	adapter, err := parseFeedAdapter(r, 0, maxSource(s.cfg.JSMaxSourceBytes))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -503,7 +503,7 @@ func (s *Server) updateFeedAdapter(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad adapter id", http.StatusBadRequest)
 		return
 	}
-	adapter, err := parseFeedAdapter(r, id)
+	adapter, err := parseFeedAdapter(r, id, maxSource(s.cfg.JSMaxSourceBytes))
 	if err != nil {
 		s.renderFeedAdapterEditor(w, r, http.StatusBadRequest,
 			adapter, feeds.FormatAdapterError(err))
@@ -526,7 +526,7 @@ func (s *Server) testFeedAdapter(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad adapter id", http.StatusBadRequest)
 		return
 	}
-	adapter, err := parseFeedAdapter(r, id)
+	adapter, err := parseFeedAdapter(r, id, maxSource(s.cfg.JSMaxSourceBytes))
 	if err != nil {
 		s.renderFeedAdapterEditor(w, r, http.StatusBadRequest,
 			adapter, feeds.FormatAdapterError(err))
@@ -722,7 +722,14 @@ func parseFeed(r *http.Request, id int64) (store.Feed, error) {
 	}, nil
 }
 
-func parseFeedAdapter(r *http.Request, id int64) (store.FeedAdapter, error) {
+func maxSource(configured int) int {
+	if configured <= 0 {
+		return 1 << 20 // default 1MB
+	}
+	return configured
+}
+
+func parseFeedAdapter(r *http.Request, id int64, maxSourceBytes int) (store.FeedAdapter, error) {
 	if err := r.ParseForm(); err != nil {
 		return store.FeedAdapter{ID: id}, err
 	}
@@ -738,7 +745,7 @@ func parseFeedAdapter(r *http.Request, id int64) (store.FeedAdapter, error) {
 	if err := store.ValidateFeedAdapter(adapter); err != nil {
 		return adapter, err
 	}
-	if err := feeds.ValidateAdapterSource(adapter.Source, 1<<20); err != nil {
+	if err := feeds.ValidateAdapterSource(adapter.Source, maxSourceBytes); err != nil {
 		return adapter, err
 	}
 	return adapter, nil

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -87,7 +87,7 @@ func TestUserSelectionAndAdminPages(t *testing.T) {
 	}
 	bgp := &fakeBGP{}
 	cfg := testConfig()
-	handler := New(cfg, db, feeds.NewSyncer(db), bgp).Handler()
+	handler := New(cfg, db, feeds.NewSyncer(db, config.Config{}), bgp).Handler()
 
 	request := httptest.NewRequest(http.MethodGet, "/", nil)
 	request.RemoteAddr = "192.168.20.15:12345"
@@ -249,7 +249,7 @@ func TestUserCatalogModeChangeRequiresPermission(t *testing.T) {
 		t.Fatal(err)
 	}
 	bgp := &fakeBGP{}
-	handler := New(testConfig(), db, feeds.NewSyncer(db), bgp).Handler()
+	handler := New(testConfig(), db, feeds.NewSyncer(db, config.Config{}), bgp).Handler()
 	form := url.Values{
 		"catalog_mode_id": {strconv.FormatInt(ipranges.ID, 10)},
 		"service":         {serviceValue("Precise", "Resolver")},
@@ -318,7 +318,7 @@ func TestLockedUserCanChangeEditableCatalogMode(t *testing.T) {
 		t.Fatal(err)
 	}
 	bgp := &fakeBGP{}
-	handler := New(testConfig(), db, feeds.NewSyncer(db), bgp).Handler()
+	handler := New(testConfig(), db, feeds.NewSyncer(db, config.Config{}), bgp).Handler()
 	form := url.Values{
 		"catalog_mode_id": {strconv.FormatInt(ipranges.ID, 10)},
 	}
@@ -376,7 +376,7 @@ func TestCategorySelectionDisablesContainedServices(t *testing.T) {
 	response := httptest.NewRecorder()
 	cfg := testConfig()
 	cfg.DefaultLanguage = "ru"
-	New(cfg, db, feeds.NewSyncer(db), &fakeBGP{}).
+	New(cfg, db, feeds.NewSyncer(db, config.Config{}), &fakeBGP{}).
 		Handler().ServeHTTP(response, request)
 	body := response.Body.String()
 	if response.Code != http.StatusOK {
@@ -411,7 +411,7 @@ func TestAdminCanManageFeeds(t *testing.T) {
 
 	bgp := &fakeBGP{}
 	cfg := testConfig()
-	handler := New(cfg, db, feeds.NewSyncer(db), bgp).Handler()
+	handler := New(cfg, db, feeds.NewSyncer(db, config.Config{}), bgp).Handler()
 	adminCookie := &http.Cookie{Name: "wdbgp_admin", Value: sessionToken(cfg.SessionSecret)}
 
 	addForm := url.Values{
@@ -510,7 +510,7 @@ func TestAdminCanEditFeedAdapter(t *testing.T) {
 	defer db.Close()
 
 	cfg := testConfig()
-	handler := New(cfg, db, feeds.NewSyncer(db), &fakeBGP{}).Handler()
+	handler := New(cfg, db, feeds.NewSyncer(db, config.Config{}), &fakeBGP{}).Handler()
 	adminCookie := &http.Cookie{Name: "wdbgp_admin", Value: sessionToken(cfg.SessionSecret)}
 	adapter, err := db.FeedAdapter(context.Background(), 1)
 	if err != nil {
@@ -604,7 +604,7 @@ func TestAdminCanTestUnsavedFeedAdapterWithoutWritingCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	syncer := feeds.NewSyncer(db)
+	syncer := feeds.NewSyncer(db, config.Config{})
 	syncer.Client = &http.Client{Transport: testRoundTripFunc(func(request *http.Request) (*http.Response, error) {
 		if request.URL.String() != feed.URL {
 			t.Fatalf("request URL = %q, want %q", request.URL, feed.URL)
@@ -713,7 +713,7 @@ func TestSelectionSavesPreserveDisabledFeedSelections(t *testing.T) {
 
 	cfg := testConfig()
 	bgp := &fakeBGP{}
-	handler := New(cfg, db, feeds.NewSyncer(db), bgp).Handler()
+	handler := New(cfg, db, feeds.NewSyncer(db, config.Config{}), bgp).Handler()
 	adminCookie := &http.Cookie{Name: "wdbgp_admin", Value: sessionToken(cfg.SessionSecret)}
 
 	tests := []struct {
@@ -850,7 +850,7 @@ func TestLocalizedPages(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			handler := New(config.Config{DefaultLanguage: test.defaultLanguage},
-				db, feeds.NewSyncer(db), &fakeBGP{}).Handler()
+				db, feeds.NewSyncer(db, config.Config{}), &fakeBGP{}).Handler()
 			request := httptest.NewRequest(http.MethodGet, test.target, nil)
 			request.RemoteAddr = "192.0.2.10:12345"
 			request.Header.Set("Accept-Language", test.accept)
@@ -950,7 +950,7 @@ func TestAdminCookieSecureAutoAllowsPlainHTTP(t *testing.T) {
 	defer db.Close()
 
 	cfg := config.Config{AdminPassword: "admin", SessionSecret: "secret", AdminCookieSecure: "auto"}
-	handler := New(cfg, db, feeds.NewSyncer(db), &fakeBGP{}).Handler()
+	handler := New(cfg, db, feeds.NewSyncer(db, config.Config{}), &fakeBGP{}).Handler()
 
 	login := url.Values{"password": {"admin"}}
 	request := httptest.NewRequest(http.MethodPost, "/admin/login", strings.NewReader(login.Encode()))
@@ -989,7 +989,7 @@ func TestAdminCookieSecureAutoHonorsTrustedForwardedProto(t *testing.T) {
 		AdminPassword: "admin", SessionSecret: "secret",
 		AdminCookieSecure: "auto", TrustProxyHeader: true,
 	}
-	handler := New(cfg, db, feeds.NewSyncer(db), &fakeBGP{}).Handler()
+	handler := New(cfg, db, feeds.NewSyncer(db, config.Config{}), &fakeBGP{}).Handler()
 
 	login := url.Values{"password": {"admin"}}
 	request := httptest.NewRequest(http.MethodPost, "/admin/login", strings.NewReader(login.Encode()))
@@ -1043,7 +1043,7 @@ func TestStatusEndpoint(t *testing.T) {
 	}
 
 	cfg := testConfig()
-	syncer := feeds.NewSyncer(db)
+	syncer := feeds.NewSyncer(db, config.Config{})
 	bgp := &fakeBGP{}
 	server := New(cfg, db, syncer, bgp)
 


### PR DESCRIPTION
## Summary

Replace hardcoded JavaScript adapter limits with configurable environment variables, giving operators control over resource constraints.

## New env vars

| Variable | Default | Description |
|----------|---------|-------------|
| WDBGP_JS_TIMEOUT | 120s | Adapter execution timeout (seconds) |
| WDBGP_JS_MAX_SOURCE | 1048576 | Max adapter source code size (bytes) |
| WDBGP_JS_MAX_RESPONSE | 16777216 | Max bytes per HTTP response (16MB) |
| WDBGP_JS_MAX_TOTAL | 67108864 | Max total download bytes (64MB) |
| WDBGP_JS_MAX_ENTRIES | 1000000 | Max entries per adapter run |
| WDBGP_JS_MAX_REQUESTS | 200 | Max HTTP requests per adapter |
| WDBGP_JS_MAX_CALL_STACK | 1000 | Max JS call stack depth |

Zero/empty values fall back to existing defaults. Backward compatible — no config changes needed for existing deployments.

## Technical notes

- Added `AdapterLimits` struct in `feeds` package
- `NewSyncer` now accepts `config.Config` and extracts limits from it
- `adapterRunner` and `adapterHTTP` carry limits as a field instead of using package-level consts
- All test callers updated to pass zero-value config (falls back to defaults)