### PR TITLE
ci: sync Docker Hub description on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,3 +55,14 @@ jobs:
           sbom: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}/wdbgp
+          readme-filepath: ./dockerhub-description.md
+          short-description: |
+            Downloads categorized IPv4/IPv6 CIDR feeds, builds a service catalog,
+            and announces prefixes to routers over BGP. Single Go binary.
+

--- a/dockerhub-description.md
+++ b/dockerhub-description.md
@@ -1,0 +1,6 @@
+wdbgp downloads categorized IPv4/IPv6 CIDR feeds, builds a service catalog, and announces prefixes selected by each user to that user's router over BGP.
+
+**GitHub:** https://github.com/andrey-vk/wdbgp
+**README:** https://github.com/andrey-vk/wdbgp#readme
+
+Single statically linked Go binary with embedded HTTP server, SQLite storage, and GoBGP. No Python or BIRD required.


### PR DESCRIPTION
Adds a step to the deploy workflow that updates the Docker Hub image description from `dockerhub-description.md` on every tagged release.

The description includes a link to the GitHub repo and README.

Requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets.