### PR TITLE
feat: runtime settings reload (StatusAllowed, StatusToken, rate limits)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Changed
+- StatusAllowed, StatusToken, RateLimitLogin, RateLimitAdmin now reloadable at runtime from DB — no restart needed.
+
 ## [0.14.0-alpha] — 2026-06-20
 
 ### Added

--- a/internal/web/handlers_admin_settings.go
+++ b/internal/web/handlers_admin_settings.go
@@ -68,6 +68,9 @@ func (s *Server) saveSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reload runtime-mutable settings so they take effect without restart
+	s.reloadRuntimeSettings(r.Context())
+
 	// Save global route filters if the fields are present in the form
 	if r.Form.Has("filter_allow") || r.Form.Has("filter_deny") {
 		if filters, err := routeFiltersFromForm(r); err == nil {

--- a/internal/web/handlers_auth.go
+++ b/internal/web/handlers_auth.go
@@ -266,22 +266,26 @@ func (s *Server) logout(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) statusAuthorized(r *http.Request) bool {
 	// Check IP
-	if len(s.cfg.StatusAllowed) > 0 {
+	s.mu.RLock()
+	cidrs := s.statusCIDRs
+	token := s.statusToken
+	s.mu.RUnlock()
+
+	if len(cidrs) > 0 {
 		clientIP := s.clientIP(r)
 		ip, err := netip.ParseAddr(clientIP)
 		if err == nil {
-			for _, cidr := range s.cfg.StatusAllowed {
-				prefix, err := netip.ParsePrefix(cidr)
-				if err == nil && prefix.Contains(ip) {
+			for _, prefix := range cidrs {
+				if prefix.Contains(ip) {
 					return true
 				}
 			}
 		}
 	}
 	// Check token
-	if s.cfg.StatusToken != "" {
+	if token != "" {
 		auth := r.Header.Get("Authorization")
-		if strings.TrimPrefix(auth, "Bearer ") == s.cfg.StatusToken {
+		if strings.TrimPrefix(auth, "Bearer ") == token {
 			return true
 		}
 	}

--- a/internal/web/middleware.go
+++ b/internal/web/middleware.go
@@ -47,6 +47,12 @@ func newRateLimiter(window time.Duration, maxRequests int) *rateLimiter {
 	}
 }
 
+func (rl *rateLimiter) SetMax(n int) {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	rl.maxRequests = n
+}
+
 func (rl *rateLimiter) allow(ip string) bool {
 	// Disable rate limiting if maxRequests <= 0
 	if rl.maxRequests <= 0 {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,7 +1,11 @@
 package web
 
 import (
+	"context"
 	"net/http"
+	"net/netip"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/andrey-vk/wdbgp/internal/config"
@@ -90,7 +94,69 @@ func New(cfg config.Config, s *store.Store, syncer *feeds.Syncer, bgp BGP) *Serv
 	handler = server.degradedMiddleware(handler)
 
 	server.handler = handler
+
+	// Load runtime-mutable settings from DB so they match persisted values
+	server.reloadRuntimeSettings(context.Background())
+
 	return server
+}
+
+// reloadRuntimeSettings reads runtime-mutable settings from DB and updates the
+// Server fields under mutex. Called once at startup and after every saveSettings.
+func (s *Server) reloadRuntimeSettings(ctx context.Context) {
+	settings, err := s.store.GetAllSettings(ctx)
+	if err != nil {
+		return // keep old values
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// StatusAllowed: comma-separated CIDRs, fall back to config if DB empty
+	if v, ok := settings["status_allowed"]; ok && v != "" {
+		s.statusCIDRs = parseCIDRs(v)
+	} else if len(s.cfg.StatusAllowed) > 0 {
+		s.statusCIDRs = parseCIDRs(strings.Join(s.cfg.StatusAllowed, ","))
+	}
+	// StatusToken: Bearer token for /status, fall back to config if DB empty
+	if v, ok := settings["status_token"]; ok && v != "" {
+		s.statusToken = v
+	} else {
+		s.statusToken = s.cfg.StatusToken
+	}
+	// Rate limits, fall back to config if DB empty
+	if v, ok := settings["rate_limit_login"]; ok && v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			s.loginLimiter.SetMax(n)
+		}
+	} else {
+		s.loginLimiter.SetMax(s.cfg.RateLimitLogin)
+	}
+	if v, ok := settings["rate_limit_admin"]; ok && v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			s.adminLimiter.SetMax(n)
+		}
+	} else {
+		s.adminLimiter.SetMax(s.cfg.RateLimitAdmin)
+	}
+}
+
+// parseCIDRs parses comma-separated CIDR strings into []netip.Prefix.
+func parseCIDRs(s string) []netip.Prefix {
+	parts := strings.FieldsFunc(s, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n' || r == '\r' || r == '\t' || r == ' '
+	})
+	var out []netip.Prefix
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		prefix, err := netip.ParsePrefix(p)
+		if err != nil {
+			continue
+		}
+		out = append(out, prefix)
+	}
+	return out
 }
 
 func (s *Server) Handler() http.Handler {

--- a/internal/web/types.go
+++ b/internal/web/types.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"html/template"
 	"net/http"
+	"net/netip"
+	"sync"
 	"time"
 
 	"github.com/andrey-vk/wdbgp/internal/config"
@@ -33,6 +35,11 @@ type Server struct {
 	startTime    time.Time
 	degraded     bool
 	degradedInfo DegradedInfo
+
+	// Runtime-mutable settings cache (reloaded from DB on save)
+	mu          sync.RWMutex
+	statusCIDRs []netip.Prefix
+	statusToken string
 }
 
 // DegradedInfo carries version mismatch details for the degraded-mode page.


### PR DESCRIPTION
## What
Settings changed in admin UI now take effect without server restart.

### Reloadable at runtime
- **StatusAllowed** — read from DB on save, used immediately via pre-parsed CIDRs
- **StatusToken** — same
- **RateLimitLogin** — updates limiter max on save 
- **RateLimitAdmin** — same

### How it works
On startup: reads DB app_settings table, falls back to config env values.  
On settings save: re-reads DB, updates Server fields under mutex.  
On each request: statusAuthorized() reads pre-parsed CIDRs under RLock — zero parsing on hot path.

### Still requires restart
SessionMaxAge, SecurityHeaders, TrustProxyHeaders — separate effort.

### Files
6 files, zero lint warnings.