### PR TITLE
perf: batch feed sync inserts, raise DB connection pool (issue #24)

### DIFF
--- a/internal/feeds/feeds.go
+++ b/internal/feeds/feeds.go
@@ -276,21 +276,8 @@ func (s *Syncer) syncOne(ctx context.Context, feed store.Feed) (int64, error) {
 		if _, err := tx.ExecContext(ctx, "DELETE FROM catalog_entries WHERE feed_id = ?", feed.ID); err != nil {
 			return err
 		}
-		statement, err := tx.PrepareContext(ctx,
-			"INSERT INTO catalog_entries(feed_id, category, service, cidr) VALUES (?, ?, ?, ?)")
-		if err != nil {
+		if err := insertCatalogEntries(ctx, tx, feed.ID, entries); err != nil {
 			return err
-		}
-		defer func() {
-			if err := statement.Close(); err != nil {
-				log.Printf("DEBUG: close statement: %v", err)
-			}
-		}()
-		for _, entry := range entries {
-			if _, err := statement.ExecContext(ctx,
-				feed.ID, entry.Category, entry.Service, entry.CIDR); err != nil {
-				return err
-			}
 		}
 		_, err = tx.ExecContext(ctx,
 			"UPDATE feeds SET last_success = ?, last_error = NULL WHERE id = ? AND url = ? AND enabled = 1",
@@ -315,6 +302,33 @@ func (s *Syncer) syncOne(ctx context.Context, feed store.Feed) (int64, error) {
 		}
 	}
 	return adapter.Revision, nil
+}
+
+// catalogEntryInsertBatchSize caps rows per multi-row INSERT. 500 rows x 4
+// bound params = 2000, safely under modernc.org/sqlite's compiled-in
+// SQLITE_MAX_VARIABLE_NUMBER (32766). A single large feed (e.g. ipranges,
+// 100k+ CIDRs) previously took one round-trip per row; batching cuts that
+// by ~500x.
+const catalogEntryInsertBatchSize = 500
+
+func insertCatalogEntries(ctx context.Context, tx *sql.Tx, feedID int64, entries []Entry) error {
+	for start := 0; start < len(entries); start += catalogEntryInsertBatchSize {
+		end := min(start+catalogEntryInsertBatchSize, len(entries))
+		chunk := entries[start:end]
+
+		placeholders := make([]string, len(chunk))
+		args := make([]any, 0, len(chunk)*4)
+		for i, entry := range chunk {
+			placeholders[i] = "(?, ?, ?, ?)"
+			args = append(args, feedID, entry.Category, entry.Service, entry.CIDR)
+		}
+		query := "INSERT INTO catalog_entries(feed_id, category, service, cidr) VALUES " +
+			strings.Join(placeholders, ",")
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func isLegacyOpenCCKFeedCategory(category string) bool {

--- a/internal/feeds/feeds_test.go
+++ b/internal/feeds/feeds_test.go
@@ -6,8 +6,10 @@ import (
 	"bytes"
 	"compress/zlib"
 	"context"
+	"database/sql"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -631,4 +633,61 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
 	return fn(request)
+}
+
+// TestInsertCatalogEntriesBatchBoundaries covers counts at, just under, and
+// just over catalogEntryInsertBatchSize, since an off-by-one in the chunk
+// loop would only surface right at those boundaries — a small feed's test
+// wouldn't catch it.
+func TestInsertCatalogEntriesBatchBoundaries(t *testing.T) {
+	for _, count := range []int{0, 1, catalogEntryInsertBatchSize - 1, catalogEntryInsertBatchSize, catalogEntryInsertBatchSize + 1, catalogEntryInsertBatchSize*2 + 7} {
+		t.Run(fmt.Sprintf("count=%d", count), func(t *testing.T) {
+			db, err := store.Open(filepath.Join(t.TempDir(), "batch.sqlite3"), false, "", false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+
+			feedList, err := db.Feeds(context.Background(), false)
+			if err != nil || len(feedList) == 0 {
+				t.Fatalf("expected at least one seeded feed, feeds=%v err=%v", feedList, err)
+			}
+			feedID := feedList[0].ID
+
+			entries := make([]Entry, count)
+			for i := range entries {
+				entries[i] = Entry{
+					Category: "cat",
+					Service:  "svc",
+					CIDR:     fmt.Sprintf("10.%d.%d.0/24", i/256, i%256),
+				}
+			}
+
+			if err := db.Transaction(context.Background(), func(tx *sql.Tx) error {
+				return insertCatalogEntries(context.Background(), tx, feedID, entries)
+			}); err != nil {
+				t.Fatalf("insertCatalogEntries failed for count=%d: %v", count, err)
+			}
+
+			var got int
+			if err := db.DB.QueryRow("SELECT COUNT(*) FROM catalog_entries WHERE feed_id = ?", feedID).Scan(&got); err != nil {
+				t.Fatal(err)
+			}
+			if got != count {
+				t.Fatalf("catalog_entries count = %d, want %d", got, count)
+			}
+
+			if count > 0 {
+				var cidr string
+				if err := db.DB.QueryRow(
+					"SELECT cidr FROM catalog_entries WHERE feed_id = ? AND category = 'cat' AND service = 'svc' ORDER BY cidr LIMIT 1",
+					feedID).Scan(&cidr); err != nil {
+					t.Fatal(err)
+				}
+				if cidr == "" {
+					t.Fatal("expected a non-empty cidr to have been inserted")
+				}
+			}
+		})
+	}
 }

--- a/internal/store/concurrency_test.go
+++ b/internal/store/concurrency_test.go
@@ -1,0 +1,66 @@
+//nolint:errcheck // test file, errors in cleanup intentionally ignored
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestConcurrentReadDoesNotBlockOnInFlightWriteTransaction guards against
+// MaxOpenConns(1) on the main DB (issue #24: the ipranges feed's 100k+ row
+// sync transaction held the single shared connection for minutes, queuing
+// every other request — dashboard, login, any DB-touching admin/user page —
+// behind it in Go's connection pool). WAL mode allows a reader to proceed
+// concurrently with an in-flight writer, but only if there's actually a
+// second connection available to serve it.
+func TestConcurrentReadDoesNotBlockOnInFlightWriteTransaction(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+
+	writeStarted := make(chan struct{})
+	releaseWrite := make(chan struct{})
+	writeDone := make(chan error, 1)
+
+	go func() {
+		writeDone <- s.Transaction(ctx, func(tx *sql.Tx) error {
+			if _, err := tx.ExecContext(ctx,
+				"INSERT INTO users(name, peer_ip, peer_asn) VALUES ('concurrent-write-test', '10.99.99.1', 65099)"); err != nil {
+				return err
+			}
+			close(writeStarted)
+			<-releaseWrite // hold the transaction open — simulates a long-running feed sync
+			return nil
+		})
+	}()
+
+	select {
+	case <-writeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("write transaction never started")
+	}
+
+	readDone := make(chan error, 1)
+	go func() {
+		var count int
+		readDone <- s.DB.QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Scan(&count)
+	}()
+
+	select {
+	case err := <-readDone:
+		if err != nil {
+			t.Fatalf("concurrent read failed: %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		close(releaseWrite) // unblock the writer so the test doesn't hang forever
+		t.Fatal("concurrent read blocked on an in-flight write transaction — MaxOpenConns is likely back down to 1")
+	}
+
+	close(releaseWrite)
+	if err := <-writeDone; err != nil {
+		t.Fatalf("write transaction failed: %v", err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -24,6 +24,19 @@ import (
 
 var ErrDBTooNew = errors.New("database schema is newer than this server version")
 
+// mainDBMaxOpenConns caps concurrent connections to the main database.
+// WAL mode (enabled below) allows one writer alongside many concurrent
+// readers, but that concurrency was wasted at MaxOpenConns(1): every
+// request — sync writes, admin reads, user reads — serialized behind
+// Go's connection pool onto the single connection, so a large feed sync
+// (e.g. ipranges, 100k+ CIDRs) holding a write transaction for minutes
+// blocked every other request in the app for that whole time. busy_timeout
+// (below) plus Store.Transaction's retry-on-busy wrapper already handle
+// writer/writer contention, so raising this just lets WAL's reader/writer
+// concurrency actually get used. Backup-DB connections (separate,
+// short-lived handles to a different file) are intentionally left at 1.
+const mainDBMaxOpenConns = 4
+
 type Store struct {
 	DB             *sql.DB
 	dbPath         string // DB file path for backup
@@ -82,7 +95,8 @@ func Open(path string, backupEnabled bool, backupDir string, autoRestoreEnabled 
 	if err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(1)
+	db.SetMaxOpenConns(mainDBMaxOpenConns)
+	db.SetMaxIdleConns(mainDBMaxOpenConns)
 	if _, err := db.Exec(`
 		PRAGMA foreign_keys = ON;
 		PRAGMA journal_mode = WAL;
@@ -314,7 +328,8 @@ CREATE TABLE IF NOT EXISTS schema_migrations (
 			if err != nil {
 				return fmt.Errorf("reopen after restore: %w", err)
 			}
-			db.SetMaxOpenConns(1)
+			db.SetMaxOpenConns(mainDBMaxOpenConns)
+			db.SetMaxIdleConns(mainDBMaxOpenConns)
 			if _, err := db.Exec(`
 				PRAGMA foreign_keys = ON;
 				PRAGMA journal_mode = WAL;


### PR DESCRIPTION
## Summary
- Batch `catalog_entries` inserts during feed sync (500-row chunks instead of one row per round-trip) — the ipranges feed (100k+ CIDRs) previously took 100k+ round-trips inside a single transaction.
- Raise the main DB's connection pool from 1 to 4, so a long-running sync transaction no longer queues every other request (dashboard, login, any DB-touching page) behind it in Go's connection pool. WAL mode was already enabled but unusable with only one connection to hand out.

Closes #24.

Not included: a live "feed is syncing" status endpoint and making the manual sync-trigger API async — that's a real design decision (fire-and-forget + polling vs. staying synchronous), left as a follow-up.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` — full suite passes
- [x] New regression test for insert batching covers batch-boundary counts (0, batchSize-1, batchSize, batchSize+1, multi-batch)
- [x] New regression test for the connection pool holds a write transaction open and asserts a concurrent read completes without queuing behind it; verified to fail against the pre-fix `MaxOpenConns(1)`

https://claude.ai/code/session_01DoJee1Jqpj4RT3SqUPPueg