### PR TITLE
Fix startup crash on stale invalid DB-stored setting value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Startup crash on a stale/invalid rate-limit setting**: a DB-stored value that parses fine but fails validation (e.g. `rate_limit_login=0`, left over from before `validateRateLimit` required a positive value) aborted `settings.New()` entirely, crashing the whole app on every future restart with no way to fix it short of editing the database file directly. Such a value now falls back to the setting's default, the same treatment a DB value that fails to even parse already got. An out-of-range env var still fails startup loudly, since that's an operator error happening right now, not a stale row from an old version.
+
 ## [0.16.0-alpha] — 2026-07-06
 
 ### Changed

--- a/internal/settings/setting.go
+++ b/internal/settings/setting.go
@@ -112,23 +112,37 @@ func newSimple[T any](defaultVal T, dbKey, envVar string, parse func(string) (T,
 
 	// Fall back to DB value (pre-loaded by caller to avoid N per-field queries),
 	// only if the env var didn't already win.
+	fromDB := false
 	if envSource == "" {
 		if dbStr, ok := dbSettings[dbKey]; ok {
 			if val, parseErr := parse(dbStr); parseErr == nil {
 				s.value = val
+				fromDB = true
 			}
 			// Invalid DB value is silently ignored — value stays at default.
 		}
 	}
 
-	// Validate the effective value, whichever source it came from.
+	// Validate the effective value, whichever source it came from. A stored
+	// DB value that fails validation (e.g. left over from before a validator
+	// was tightened, or from a version that allowed a value this one
+	// doesn't) falls back to the default rather than taking the whole
+	// process down on every future restart — the same treatment as a DB
+	// value that fails to even parse, just above. An env var or the
+	// hardcoded default failing validation is still a hard error: an
+	// operator-supplied env var must fail loudly, and a hardcoded default
+	// failing its own validator is a bug in this file, not a stale DB row.
 	if s.validate != nil {
 		if err := s.validate(s.value); err != nil {
-			source := envSource
-			if source == "" {
-				source = "default"
+			if fromDB {
+				s.value = defaultVal
+			} else {
+				source := envSource
+				if source == "" {
+					source = "default"
+				}
+				return nil, fmt.Errorf("settings: invalid value for %s (%s): %w", dbKey, source, err)
 			}
-			return nil, fmt.Errorf("settings: invalid value for %s (%s): %w", dbKey, source, err)
 		}
 	}
 
@@ -166,6 +180,7 @@ func newComplex[T any](defaultJSON string, dbKey, envVar string, parse func(stri
 		}
 	}
 
+	fromDB := false
 	if envSource == "" {
 		// Fall back to DB value (pre-loaded by caller).
 		useDefault := true
@@ -173,6 +188,7 @@ func newComplex[T any](defaultJSON string, dbKey, envVar string, parse func(stri
 			if val, parseErr := parse(dbStr); parseErr == nil {
 				s.value = val
 				useDefault = false
+				fromDB = true
 			}
 			// Invalid DB value -> fall back to parsed default.
 		}
@@ -185,14 +201,25 @@ func newComplex[T any](defaultJSON string, dbKey, envVar string, parse func(stri
 		}
 	}
 
-	// Validate the effective value, whichever source it came from.
+	// Validate the effective value, whichever source it came from. A
+	// stored DB value that fails validation falls back to the parsed
+	// default rather than taking the whole process down — see the
+	// matching comment in newSimple.
 	if validate != nil {
 		if err := validate(s.value); err != nil {
-			source := envSource
-			if source == "" {
-				source = "default"
+			if fromDB {
+				val, parseErr := parse(defaultJSON)
+				if parseErr != nil {
+					return nil, fmt.Errorf("settings: default value %q for %s does not parse: %w", defaultJSON, dbKey, parseErr)
+				}
+				s.value = val
+			} else {
+				source := envSource
+				if source == "" {
+					source = "default"
+				}
+				return nil, fmt.Errorf("settings: invalid value for %s (%s): %w", dbKey, source, err)
 			}
-			return nil, fmt.Errorf("settings: invalid value for %s (%s): %w", dbKey, source, err)
 		}
 	}
 

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -882,6 +882,40 @@ func TestRateLimitValidation(t *testing.T) {
 	}
 }
 
+// TestNewSettings_StaleDBValueFallsBackToDefault guards against a real
+// startup crash: a DB row for rate_limit_login=0 (e.g. from before
+// validateRateLimit required a positive value, or written some other way
+// that predates the current validator) parses fine as an int but fails
+// validation. Before this test existed, that failure aborted New() itself —
+// every future restart, including the one an admin would need to fix it
+// through the running app — leaving no way to recover short of editing the
+// DB file directly. A stale/invalid DB value must fall back to the default
+// instead, the same way a DB value that fails to even parse already does.
+func TestNewSettings_StaleDBValueFallsBackToDefault(t *testing.T) {
+	store := newMockStore()
+	store.settings["rate_limit_login"] = "0"
+	s, err := New(store)
+	if err != nil {
+		t.Fatalf("New() should not fail on a stale invalid DB value, got: %v", err)
+	}
+	if got, want := s.RateLimitLogin.Get(), 5; got != want {
+		t.Errorf("RateLimitLogin = %d, want %d (default, falling back from invalid DB value)", got, want)
+	}
+}
+
+// TestNewSettings_InvalidEnvRateLimitStillFails guards the other half of the
+// same fallback logic: only a DB-sourced invalid value degrades gracefully.
+// An operator-supplied env var that's out of range must still fail startup
+// loudly — unlike a stale DB row, there's no silent, safe substitute for a
+// value someone explicitly configured just now.
+func TestNewSettings_InvalidEnvRateLimitStillFails(t *testing.T) {
+	t.Setenv("WDBGP_RATE_LIMIT_LOGIN", "0")
+	store := newMockStore()
+	if _, err := New(store); err == nil {
+		t.Fatal("expected New() to fail for an out-of-range env var value")
+	}
+}
+
 // TestSessionMaxAgeValidation guards against session_max_age being settable
 // to an absurdly large value (sessions that never meaningfully expire) or a
 // tiny nonzero one (sessions expiring almost immediately, which looks like


### PR DESCRIPTION
## Summary
- Reported error: `settings: invalid value for rate_limit_login (default): must be positive, got 0` crashing the app at startup.
- Root cause: `newSimple`/`newComplex` validated the effective value regardless of source, but only a DB value that fails to *parse* silently fell back to the default — a DB value that parses fine but fails *validation* (e.g. a `rate_limit_login=0` row left over from before `validateRateLimit` required a positive value) hard-errored `settings.New()` instead, crashing the whole process on every restart with no way to recover short of editing the SQLite file directly.
- Fix: a DB-sourced value that fails validation now falls back to the default, matching the existing parse-failure behavior. An out-of-range **env var** still fails startup loudly (unchanged) — that's a live operator error, not a stale row from an older version.

## Test plan
- [x] New regression test: seed DB with `rate_limit_login=0`, confirm `settings.New()` succeeds and falls back to the default (5) instead of erroring.
- [x] New test: confirm an out-of-range **env var** value still fails `settings.New()` as before.
- [x] Full existing settings test suite still passes (including `TestRateLimitValidation`, which covers `Set()`-time rejection — unaffected, since this fix only changes startup-time DB-value handling).
- [x] `go build`, `go vet`, `golangci-lint run`, `go test ./...` all clean across the whole repo.