### PR TITLE
Fix fixed-peer connections torn down by redundant post-accept MD5 set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Fixed (non-loopback) BGP peers with a password could get their connection torn down right after a successful, correctly-authenticated TCP handshake**: `AcceptWithOpen` redundantly re-set the TCP MD5 key on the already-accepted socket, even though the kernel already verified the signature during the handshake using the key `applyListenerMD5` installed on the listener, and automatically carries that key over to the accepted socket. On some kernels this redundant `setsockopt` call itself fails (`invalid argument`), and the failure was treated as fatal — closing a connection that had already proven its signature was correct. Removed the redundant call; loopback peers are unaffected (TCP MD5 was never enforceable there, so they already relied solely on the OPEN message's password field, which still applies).
+
 ## [0.16.0-alpha] — 2026-07-06
 
 ### Changed

--- a/internal/bgp/md5.go
+++ b/internal/bgp/md5.go
@@ -9,39 +9,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// setTCPMD5OnConn sets the TCP MD5 signature on an already-connected socket.
-// Used for passive (accepted) connections.
-// Skips loopback addresses because many kernels (including WSL2) do not
-// support TCP MD5 on loopback.
-//
-// NOTE: Prefer applyListenerMD5 for passive connections — it sets MD5 on the
-// listener socket before the TCP handshake, which is the correct timing per
-// RFC 2385. Setting MD5 on an already-accepted socket is too late for the
-// kernel to enforce during the handshake.
-func setTCPMD5OnConn(conn net.Conn, addr netip.Addr, password string) error {
-	if password == "" || addr.IsLoopback() {
-		return nil
-	}
-
-	sc, ok := conn.(syscall.Conn)
-	if !ok {
-		return fmt.Errorf("tcp md5: conn is not syscall.Conn")
-	}
-	rawConn, err := sc.SyscallConn()
-	if err != nil {
-		return fmt.Errorf("tcp md5: syscall conn: %w", err)
-	}
-
-	var setErr error
-	ctrlErr := rawConn.Control(func(fd uintptr) {
-		setErr = setTCPMD5OnFd(int(fd), addr, password)
-	})
-	if ctrlErr != nil {
-		return fmt.Errorf("tcp md5: control: %w", ctrlErr)
-	}
-	return setErr
-}
-
 // applyListenerMD5 sets TCP MD5 keys on the listener socket for all configured
 // peers that have passwords. This must be called before accepting connections
 // so the kernel enforces MD5 during the TCP handshake (RFC 2385).

--- a/internal/bgp/peer_fsm.go
+++ b/internal/bgp/peer_fsm.go
@@ -394,34 +394,30 @@ func (p *Peer) AcceptWithOpen(conn net.Conn, openIn *OpenMessage) {
 	}
 
 	// Password authentication:
-	//   - TCP MD5 (RFC 2385) is the primary mechanism, set on the socket.
-	//   - If TCP MD5 is not available (e.g., loopback), validate via the
-	//     Password field in the OPEN message as a fallback.
-	//   - Dynamic peers (0.0.0.0) on non-loopback cannot use MD5 at the
-	//     handshake level (listener can't preinstall keys for 0.0.0.0).
+	//   - TCP MD5 (RFC 2385) is the primary mechanism. For a non-loopback
+	//     peer, it's already enforced by the kernel during the handshake
+	//     using the key applyListenerMD5 installed on the listener before
+	//     Accept — the kernel copies that key into this accepted socket
+	//     automatically as part of completing the handshake, so reaching
+	//     this point already proves the signature matched. There is
+	//     nothing left to set here; a prior attempt to redundantly re-set
+	//     the same key on the already-accepted socket could itself fail
+	//     (observed: setsockopt EINVAL on some kernels) and would
+	//     needlessly tear down an already-authenticated connection.
+	//   - TCP MD5 is not enforceable on loopback (many kernels, including
+	//     WSL2, don't support it there) or for dynamic (0.0.0.0) peers on
+	//     non-loopback (the listener can't preinstall a key for a wildcard
+	//     address). Loopback validates the Password field in the OPEN
+	//     message instead; non-loopback dynamic peers are unauthenticated
+	//     here.
 	remoteAddr, _ := netip.ParseAddrPort(conn.RemoteAddr().String()) //nolint:errcheck // always valid from kernel accept()
 	remoteIP := remoteAddr.Addr()
-	if p.cfg.Password != "" {
-		if p.cfg.Address.IsUnspecified() && !remoteIP.IsLoopback() {
-			// Dynamic peer on non-loopback: cannot authenticate.
-			// TCP MD5 cannot be preinstalled for wildcard addresses,
-			// and OPEN password is not validated. Accept silently.
-		} else if err := setTCPMD5OnConn(conn, remoteIP, p.cfg.Password); err != nil {
-			p.logger.Error("accept: tcp md5 set failed", "error", err)
-			if err := conn.Close(); err != nil {
-				p.logger.Debug("close connection", "error", err)
-			}
-			return
+	if p.cfg.Password != "" && remoteIP.IsLoopback() && openIn.Password != p.cfg.Password {
+		p.sendNotification(conn, 5, 0, nil)
+		if err := conn.Close(); err != nil {
+			p.logger.Debug("close connection", "error", err)
 		}
-		// Fallback: validate password from OPEN message when TCP MD5
-		// is skipped (e.g., on loopback where MD5 is not enforced).
-		if remoteIP.IsLoopback() && openIn.Password != p.cfg.Password {
-			p.sendNotification(conn, 5, 0, nil)
-			if err := conn.Close(); err != nil {
-				p.logger.Debug("close connection", "error", err)
-			}
-			return
-		}
+		return
 	}
 
 	// Send OPEN — hold time negotiation per RFC 4271


### PR DESCRIPTION
## Summary
- Reported error: `accept: tcp md5 set failed error="invalid argument"` closing an otherwise-legitimate BGP session from a non-loopback fixed peer (172.16.200.20).
- Root cause: `AcceptWithOpen` called `setTCPMD5OnConn` to (redundantly) re-set the TCP MD5 key on the already-accepted socket for non-loopback peers. This is unnecessary: the kernel already verified the RFC 2385 signature during the TCP handshake using the key `applyListenerMD5` installed on the listener before `Accept`, and automatically carries that key over to the new accepted socket as part of completing the handshake (`tcp_v4_syn_recv_sock`). Reaching `AcceptWithOpen` at all already proves the signature matched.
- On some kernels this redundant `setsockopt` call itself fails (`EINVAL`), and the failure path treated it as fatal, closing an already-correctly-authenticated connection.
- Fix: removed the redundant call (and the now-unused `setTCPMD5OnConn`/its call site). Loopback peers are unaffected: TCP MD5 isn't enforceable on loopback on many kernels (including WSL2) in the first place, so they already relied solely on the OPEN message's `Password` field, which this change preserves unchanged.

## Test plan
- [x] `go build`, `go vet`, `golangci-lint run`, `go test ./...` all clean across the whole repo.
- [ ] No new automated test: this bug (and any regression back to it) is only observable on a non-loopback host with real kernel `TCP_MD5SIG` support — not reproducible in this sandbox/CI (same limitation noted in #28's test plan). The existing loopback-based `TestPasswordAuthCorrect`/`TestPasswordAuthWrong` etc. all still pass unchanged, since the removed call was already a no-op on loopback.
- [ ] Real-world validation: confirm the fixed (non-loopback) peer at 172.16.200.20 now establishes and stays up.