### PR TITLE
Show running server version in the admin UI footer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,11 @@ jobs:
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # meta.outputs.version is the semver from the release tag (or
+          # the raw tag on workflow_dispatch), so the version the binary
+          # reports always matches the Docker tag it shipped under.
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
 
       - name: Install Docker Scout CLI
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+- **The admin UI footer now shows the running server version.** The build stamps the version into the binary via `-ldflags -X` (`internal/version`): release images get the semver matching their Docker tag (deploy passes the metadata-action version as the `VERSION` build arg, so they can't drift), hand-built images can pass their own (`docker build --build-arg VERSION="$(git describe --tags --dirty)"` tells apart a working-tree build from the release it forked from), and anything else reports `dev`. The version rides the existing `/api/admin/me` bootstrap response — admin-authenticated only, so anonymous visitors can't fingerprint the exact build — and is logged once at startup.
+
 ## [0.17.4-alpha] — 2026-07-10
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,11 @@ COPY --from=frontend /src/webgui/dist ./webgui/dist
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETVARIANT
+ARG VERSION=dev
 RUN set -eux; \
     if [ "$TARGETARCH" = "arm" ]; then export GOARM="${TARGETVARIANT#v}"; fi; \
     CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" \
-    go build -trimpath -ldflags="-s -w" -o /out/wdbgp ./cmd/wdbgp
+    go build -trimpath -ldflags="-s -w -X github.com/andrey-vk/wdbgp/internal/version.Version=${VERSION}" -o /out/wdbgp ./cmd/wdbgp
 
 FROM --platform=$BUILDPLATFORM alpine:3.23 AS certs
 

--- a/cmd/wdbgp/main.go
+++ b/cmd/wdbgp/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/andrey-vk/wdbgp/internal/logging"
 	"github.com/andrey-vk/wdbgp/internal/settings"
 	"github.com/andrey-vk/wdbgp/internal/store"
+	"github.com/andrey-vk/wdbgp/internal/version"
 	"github.com/andrey-vk/wdbgp/internal/web"
 )
 
@@ -109,6 +110,7 @@ func serve(s *settings.Settings, db *store.Store) error {
 	}
 
 	logging.Info("starting application",
+		"version", version.Version,
 		"bgp_asn", s.LocalASN.Get(),
 		"bgp_port", s.BGPPort.Get(),
 		"http_address", fmt.Sprintf("%s:%d", s.Host.Get(), s.Port.Get()),

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,11 @@
+// Package version carries the build-time version string.
+package version
+
+// Version is overwritten at build time via
+//
+//	-ldflags "-X github.com/andrey-vk/wdbgp/internal/version.Version=..."
+//
+// Release images get the semver matching their Docker tag (from the
+// release tag via deploy.yml); runtime/build.sh stamps `git describe`
+// output. "dev" means a build that bypassed both.
+var Version = "dev"

--- a/internal/web/handlers_api_auth.go
+++ b/internal/web/handlers_api_auth.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/andrey-vk/wdbgp/internal/logging"
+	"github.com/andrey-vk/wdbgp/internal/version"
 )
 
 // apiResponse is a standard JSON response envelope.
@@ -95,9 +96,15 @@ func (s *Server) apiAdminLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 // apiAdminMe handles GET /api/admin/me.
-// Requires valid admin session. Returns whether the user is authenticated.
+// Requires valid admin session. Returns whether the user is authenticated,
+// plus the running server version — this endpoint is the SPA's bootstrap
+// call, and keeping the version behind admin auth avoids advertising the
+// exact build to anonymous visitors.
 func (s *Server) apiAdminMe(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]bool{"authenticated": true})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"authenticated":  true,
+		"server_version": version.Version,
+	})
 }
 
 // apiAdminLogout handles POST /api/admin/logout.

--- a/internal/web/handlers_api_auth_test.go
+++ b/internal/web/handlers_api_auth_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/andrey-vk/wdbgp/internal/feeds"
 	"github.com/andrey-vk/wdbgp/internal/store"
+	"github.com/andrey-vk/wdbgp/internal/version"
 )
 
 // =============================================================================
@@ -121,5 +123,71 @@ func TestLoginCookieExpiresWithMaxAge(t *testing.T) {
 
 	if c.MaxAge != 3600 {
 		t.Fatalf("MaxAge = %d, want 3600", c.MaxAge)
+	}
+}
+
+// =============================================================================
+// TestAdminMeReturnsServerVersion — /api/admin/me is the SPA's bootstrap
+// call and the only place the running build version is exposed; it must be
+// present for authenticated admins (the footer shows it) and the endpoint
+// itself must stay behind auth so anonymous visitors can't fingerprint the
+// exact build.
+// =============================================================================
+
+func TestAdminMeReturnsServerVersion(t *testing.T) {
+	db, err := store.Open(":memory:", false, "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if errClose := db.Close(); errClose != nil {
+			t.Logf("close: %v", errClose)
+		}
+	}()
+
+	handler := New(testSettings(), db, feeds.NewSyncer(db, testSettings()), &fakeBGP{}).Handler()
+
+	// Unauthenticated: 401, no version leak.
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/me", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated /api/admin/me: status=%d, want 401", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "server_version") {
+		t.Fatal("unauthenticated /api/admin/me response leaks server_version")
+	}
+
+	// Log in, replay the session cookie.
+	loginReq := httptest.NewRequest(http.MethodPost, "/api/admin/login", strings.NewReader(`{"password": "admin"}`))
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginRec := httptest.NewRecorder()
+	handler.ServeHTTP(loginRec, loginReq)
+	if loginRec.Code != http.StatusOK {
+		t.Fatalf("login: status=%d, want 200", loginRec.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/admin/me", nil)
+	for _, c := range loginRec.Result().Cookies() {
+		req.AddCookie(c)
+	}
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("authenticated /api/admin/me: status=%d, want 200", rec.Code)
+	}
+
+	var resp struct {
+		Authenticated bool   `json:"authenticated"`
+		ServerVersion string `json:"server_version"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.Authenticated {
+		t.Fatal("authenticated = false, want true")
+	}
+	if resp.ServerVersion != version.Version {
+		t.Fatalf("server_version = %q, want %q", resp.ServerVersion, version.Version)
 	}
 }

--- a/webgui/src/admin/layout/AppFooter.vue
+++ b/webgui/src/admin/layout/AppFooter.vue
@@ -1,8 +1,14 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { useAuthStore } from '@/admin/stores/auth'
+
+const auth = useAuthStore()
+</script>
 
 <template>
   <div class="layout-footer">
-    WDBGP —
+    WDBGP
+    <span v-if="auth.serverVersion" class="text-muted-color">{{ auth.serverVersion }}</span>
+    —
     <a
       href="https://github.com/andrey-vk/wdbgp"
       target="_blank"

--- a/webgui/src/admin/stores/__tests__/auth.test.ts
+++ b/webgui/src/admin/stores/__tests__/auth.test.ts
@@ -41,6 +41,20 @@ describe('auth store', () => {
     expect(result).toBe(true)
   })
 
+  it('checkAuth() picks up server_version from /api/admin/me', async () => {
+    mockGet.mockResolvedValue({ data: { authenticated: true, server_version: '0.17.4-alpha' } })
+    const store = useAuthStore()
+    await store.checkAuth()
+    expect(store.serverVersion).toBe('0.17.4-alpha')
+  })
+
+  it('checkAuth() leaves serverVersion empty when the response omits it', async () => {
+    mockGet.mockResolvedValue({ data: { authenticated: true } })
+    const store = useAuthStore()
+    await store.checkAuth()
+    expect(store.serverVersion).toBe('')
+  })
+
   it('checkAuth() sets authenticated=false on 401', async () => {
     mockGet.mockRejectedValue({ response: { status: 401 } })
     const store = useAuthStore()

--- a/webgui/src/admin/stores/auth.ts
+++ b/webgui/src/admin/stores/auth.ts
@@ -7,6 +7,7 @@ let _checkPromise: Promise<boolean> | null = null
 export const useAuthStore = defineStore('auth', () => {
   const isAuthenticated = ref(false)
   const isChecking = ref(true) // true while initial session check is in progress
+  const serverVersion = ref('') // running server build, from /admin/me (empty until authenticated)
 
   async function login(password: string): Promise<string | null> {
     try {
@@ -36,6 +37,9 @@ export const useAuthStore = defineStore('auth', () => {
       try {
         const response = await apiClient.get('/admin/me', { skipAuthRedirect: true })
         isAuthenticated.value = response.data.authenticated === true
+        if (isAuthenticated.value && typeof response.data.server_version === 'string') {
+          serverVersion.value = response.data.server_version
+        }
         return isAuthenticated.value
       } catch {
         isAuthenticated.value = false
@@ -58,5 +62,5 @@ export const useAuthStore = defineStore('auth', () => {
     isChecking.value = false
   }
 
-  return { isAuthenticated, isChecking, login, checkAuth, logout }
+  return { isAuthenticated, isChecking, serverVersion, login, checkAuth, logout }
 })


### PR DESCRIPTION
## Summary

The admin UI footer now shows the version of the running server build — until now there was no way to tell from the UI (or the logs) which build a deployment is actually running, which cost real time during the recent BGP send-path debugging.

- New `internal/version` package holding a `Version` string (default `"dev"`), overwritten at link time via `-ldflags -X`.
- `Dockerfile` accepts a `VERSION` build arg and stamps it into the binary.
- `deploy.yml` passes `steps.meta.outputs.version` (the semver derived from the release tag) as that build arg — the version the binary reports is derived from the same metadata-action output as the Docker tag, so they cannot drift. Hand-built images can pass their own, e.g. `--build-arg VERSION="$(git describe --tags --dirty)"`.
- The version rides the existing `GET /api/admin/me` bootstrap response (`server_version`). Deliberately **admin-authenticated only** — no public endpoint advertises the exact build to anonymous visitors.
- The auth store picks it up during the session check and `AppFooter.vue` renders it next to the WDBGP name.
- Also logged once at startup (`starting application version=...`), so every log capture identifies the build.

## Testing

- New Go test `TestAdminMeReturnsServerVersion`: authenticated `/api/admin/me` carries `server_version`; unauthenticated requests get a 401 with no version leak.
- New vitest cases: auth store picks up `server_version` / leaves it empty when absent.
- Verified `-ldflags` stamping end-to-end on a local build (`strings` shows the injected version).
- Full Go test suite (`-race`), `golangci-lint`, ESLint, and `vue-tsc` all clean.