### PR TITLE
Fix dashboard stat cards: equal heights and working icon colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Leaving a user's Selections page no longer fires a stray `count-selections` request.** The 300ms debounce behind the live prefix counter survived navigation: the timer was never cleared on unmount, and the user id — computed live from the route — turned `NaN` once the route lost its `:id` param, producing a `POST /api/admin/users/NaN/count-selections` that the server rejected with 400 (a console error with no user-visible harm). The timer is now cleared on unmount and the count request bails when the id is gone.
 - **Dashboard stat cards render correctly again.** The last card in each dashboard grid row appeared taller than its siblings: the template's `.card` style carried a `margin-bottom` with a `:last-child` reset, and inside a CSS grid row that margin made every card except the last stretch short. The margin is gone — card spacing was already handled by explicit gap/margin utilities everywhere. The stat-card icon colors are also back: the classes were built by string concatenation (`'bg-' + color + '-100'`), which Tailwind's scanner can't see, so most of them had no CSS and only two rendered by accident (as literals used elsewhere). The classes are now spelled out verbatim per card, including the dark-theme variants.
 
 ## [0.17.4-alpha] — 2026-07-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+- **Dashboard stat cards render correctly again.** The last card in each dashboard grid row appeared taller than its siblings: the template's `.card` style carried a `margin-bottom` with a `:last-child` reset, and inside a CSS grid row that margin made every card except the last stretch short. The margin is gone — card spacing was already handled by explicit gap/margin utilities everywhere. The stat-card icon colors are also back: the classes were built by string concatenation (`'bg-' + color + '-100'`), which Tailwind's scanner can't see, so most of them had no CSS and only two rendered by accident (as literals used elsewhere). The classes are now spelled out verbatim per card, including the dark-theme variants.
+
 ## [0.17.4-alpha] — 2026-07-10
 
 ### Added

--- a/webgui/src/admin/views/Dashboard.vue
+++ b/webgui/src/admin/views/Dashboard.vue
@@ -21,14 +21,16 @@ onUnmounted(() => {
   stopStatusPolling()
 })
 
-// Stat cards data
+// Stat cards data. Icon classes are hardcoded literals: Tailwind only
+// generates classes it finds verbatim in the source, so building names
+// like 'bg-' + color + '-100' at runtime yields classes with no CSS.
 const stats = computed(() => {
   if (!data.value) return []
   return [
-    { label: t('dashboard.prefixes'), value: data.value.prefixes?.toLocaleString() || '0', icon: 'pi-globe', color: 'blue' },
-    { label: t('dashboard.bgp_peers'), value: `${data.value.bgp?.connected_peers || 0}/${data.value.bgp?.total_peers || 0}`, icon: 'pi-sitemap', color: 'green' },
-    { label: t('dashboard.feeds'), value: `${data.value.feeds?.enabled || 0}/${data.value.feeds?.total || 0}`, icon: 'pi-download', color: 'teal' },
-    { label: t('dashboard.users'), value: data.value.users?.total || 0, icon: 'pi-users', color: 'purple' },
+    { label: t('dashboard.prefixes'), value: data.value.prefixes?.toLocaleString() || '0', icon: 'pi-globe', boxClass: 'bg-blue-100 dark:bg-blue-400/10', iconClass: 'text-blue-500' },
+    { label: t('dashboard.bgp_peers'), value: `${data.value.bgp?.connected_peers || 0}/${data.value.bgp?.total_peers || 0}`, icon: 'pi-sitemap', boxClass: 'bg-green-100 dark:bg-green-400/10', iconClass: 'text-green-500' },
+    { label: t('dashboard.feeds'), value: `${data.value.feeds?.enabled || 0}/${data.value.feeds?.total || 0}`, icon: 'pi-download', boxClass: 'bg-teal-100 dark:bg-teal-400/10', iconClass: 'text-teal-500' },
+    { label: t('dashboard.users'), value: data.value.users?.total || 0, icon: 'pi-users', boxClass: 'bg-purple-100 dark:bg-purple-400/10', iconClass: 'text-purple-500' },
   ]
 })
 
@@ -181,8 +183,8 @@ async function fetchStatuses() {
               <div class="text-gray-500 dark:text-gray-400 text-sm mb-1">{{ stat.label }}</div>
               <div class="text-2xl font-semibold">{{ stat.value }}</div>
             </div>
-            <div :class="['w-10 h-10 rounded-lg flex items-center justify-center', 'bg-' + stat.color + '-100', 'dark:bg-' + stat.color + '-400/10']">
-              <i :class="['pi', stat.icon, 'text-' + stat.color + '-500', 'text-xl']" />
+            <div :class="['w-10 h-10 rounded-lg flex items-center justify-center', stat.boxClass]">
+              <i :class="['pi', stat.icon, stat.iconClass, 'text-xl']" />
             </div>
           </div>
         </div>

--- a/webgui/src/admin/views/UserSelectionsPage.vue
+++ b/webgui/src/admin/views/UserSelectionsPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useToast } from 'primevue/usetoast'
@@ -228,6 +228,11 @@ function debounceCount(): void {
 }
 
 async function fetchCounts(): Promise<void> {
+  // Code from this page can outlive its route (the debounce timer, or an
+  // in-flight loadData chain resuming after navigation). By then
+  // route.params.id is gone and userId computes to NaN — don't fire a
+  // request to /users/NaN/count-selections.
+  if (!Number.isInteger(userId.value)) return
   const token = countRequest.next()
   const selections = {
     ...buildSelectionPayload(),
@@ -289,6 +294,13 @@ function goBack() {
 // ── Lifecycle ───────────────────────────────────────────────
 onMounted(() => {
   loadData()
+})
+
+onUnmounted(() => {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer)
+    debounceTimer = null
+  }
 })
 </script>
 

--- a/webgui/src/admin/views/__tests__/KeyBehaviors.test.ts
+++ b/webgui/src/admin/views/__tests__/KeyBehaviors.test.ts
@@ -322,3 +322,55 @@ describe('UsersPage BGP password', () => {
     expect((toggle.element as HTMLInputElement).checked).toBe(true)
   })
 })
+
+// ============================================================
+// Regression: leaving the user-selections page with the count debounce
+// pending fired POST /admin/users/NaN/count-selections — the timer
+// survived unmount, and userId (computed from route.params.id) turned
+// NaN once the route no longer carried an :id param.
+// ============================================================
+
+describe('UserSelectionsPage stray count request', () => {
+  it('does not fire count-selections after the page is left mid-debounce', async () => {
+    mockRouteParams = { id: '4' }
+    mockGet.mockImplementation((url: string) => {
+      if (url === '/admin/users/4/catalog') {
+        return Promise.resolve({
+          data: {
+            user: { id: 4, name: 'Test User', catalog_mode_id: 1 },
+            modes: [{ id: 1, name: 'Default' }],
+            catalog: { Video: ['youtube'] },
+            prefix_counts: { v4: { Video: { youtube: 10 } }, v6: {} },
+            selections: { categories: [], services: [] },
+          },
+        })
+      }
+      return Promise.resolve({ data: {} })
+    })
+    mockPost.mockResolvedValue({ data: { v4: 10, v6: 0, delta_v4: 0, delta_v6: 0 } })
+
+    const UserSelectionsPage = (await import('@/admin/views/UserSelectionsPage.vue')).default
+    const wrapper = mount(UserSelectionsPage, {
+      global: { stubs: stubPrimeVueComponents() },
+    })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    await nextTick()
+
+    // The initial load counts with the real id.
+    expect(mockPost).toHaveBeenCalledWith('/admin/users/4/count-selections', expect.anything())
+    mockPost.mockClear()
+
+    // Toggle a category: arms the 300ms debounced recount.
+    const label = wrapper.findAll('span').find((s) => s.text() === 'Video')
+    expect(label).toBeDefined()
+    await label!.trigger('click')
+
+    // Navigate away before the debounce fires: the route loses :id and
+    // the component unmounts.
+    delete mockRouteParams.id
+    wrapper.unmount()
+
+    await new Promise(resolve => setTimeout(resolve, 400))
+    expect(mockPost).not.toHaveBeenCalled()
+  })
+})

--- a/webgui/src/assets/layout/_utils.scss
+++ b/webgui/src/assets/layout/_utils.scss
@@ -5,15 +5,14 @@
     clear: both;
 }
 
+// No default margin: inside CSS grid rows the margin made every card except
+// the :last-child stretch short (visibly unequal heights). Spacing between
+// cards is the caller's job (mt-*, mb-*, gap utilities), which is already how
+// every usage in the admin SPA works.
 .card {
     background: var(--surface-card);
     padding: 2rem;
-    margin-bottom: 2rem;
     border-radius: var(--content-border-radius);
-
-    &:last-child {
-        margin-bottom: 0;
-    }
 }
 
 .p-toast {


### PR DESCRIPTION
## Summary

Two rendering defects in the dashboard, most visible on the last stat card ("Users"), plus a stray-request fix on the Selections page.

- **Unequal card heights in grid rows.** `_utils.scss` gave `.card` a `margin-bottom: 2rem` with a `:last-child` reset. In a CSS grid row, items stretch to the row height *minus their own margin*, so every card except the last ended 28px short — the last card in each row (stat row and the peers/system row) rendered visibly taller. The margin is removed; every `.card` usage in the admin SPA already handles spacing with explicit `mt-*`/`mb-*`/`gap` utilities (verified by audit), so nothing else moves.

- **Icon colors built by string concatenation.** `Dashboard.vue` composed classes as `'bg-' + color + '-100'` / `'text-' + color + '-500'`, which Tailwind's static scanner cannot see, so most of those classes had no CSS in the built bundle. Only `text-green-500` and `bg-purple-100` worked, by accident — they appear as literals in unrelated components. The classes are now hardcoded verbatim per card, including the `dark:bg-*-400/10` variants.

- **Stray `POST /api/admin/users/NaN/count-selections` (400) when leaving the Selections page.** The live prefix counter's 300ms debounce timer was never cleared on unmount, and the user id is computed live from `route.params.id` — navigating away inside the debounce window (or with `loadData` still in flight) re-evaluated it to `NaN` and fired the request. The timer is cleared on unmount and `fetchCounts` bails when the route no longer carries a usable id. Covered by a regression test that fails against the unfixed component.

Dashboard fixes verified by rendering in headless chromium against a realistic DB: all four stat cards measure identical heights, both bottom cards match, and all `bg-*-100`/`text-*-500`/dark-variant classes resolve to real CSS in both themes.

## Testing
- `npm run lint`, `vue-tsc --noEmit`, `vitest run` (145 tests) — all green
- New regression test for the stray count request (fails on old code, passes with fix)
- Visual verification in headless chromium, light + dark themes