### PR TITLE
docs: point Docker version badge at the latest stable tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/andrey-vk/wdbgp/actions/workflows/tests.yml/badge.svg)](https://github.com/andrey-vk/wdbgp/actions/workflows/tests.yml)
 [![Publish Docker Image](https://github.com/andrey-vk/wdbgp/actions/workflows/deploy.yml/badge.svg)](https://github.com/andrey-vk/wdbgp/actions/workflows/deploy.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Docker Alpha Version](https://img.shields.io/docker/v/wh1ted/wdbgp/alpha?label=docker%20alpha)](https://hub.docker.com/r/wh1ted/wdbgp/tags)
+[![Docker Image Version](https://img.shields.io/docker/v/wh1ted/wdbgp/latest?label=docker)](https://hub.docker.com/r/wh1ted/wdbgp/tags)
 [![Docker Pulls](https://img.shields.io/docker/pulls/wh1ted/wdbgp)](https://hub.docker.com/r/wh1ted/wdbgp)
 ![Go](https://img.shields.io/badge/Go-1.26-00ADD8)
 ![Alpine](https://img.shields.io/badge/Alpine-3.23-0d597f)
@@ -11,7 +11,7 @@
 ![RouterOS](https://img.shields.io/badge/RouterOS-container-blue)
 ![Dual Stack](https://img.shields.io/badge/IP-IPv4%20%2B%20IPv6-blueviolet)
 ![Vue 3](https://img.shields.io/badge/Vue-3-4FC08D)
-![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6)
+![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6)
 
 [Русская версия](README.ru.md)
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/andrey-vk/wdbgp/actions/workflows/tests.yml/badge.svg)](https://github.com/andrey-vk/wdbgp/actions/workflows/tests.yml)
 [![Publish Docker Image](https://github.com/andrey-vk/wdbgp/actions/workflows/deploy.yml/badge.svg)](https://github.com/andrey-vk/wdbgp/actions/workflows/deploy.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Docker Alpha Version](https://img.shields.io/docker/v/wh1ted/wdbgp/alpha?label=docker%20alpha)](https://hub.docker.com/r/wh1ted/wdbgp/tags)
+[![Docker Image Version](https://img.shields.io/docker/v/wh1ted/wdbgp/latest?label=docker)](https://hub.docker.com/r/wh1ted/wdbgp/tags)
 [![Docker Pulls](https://img.shields.io/docker/pulls/wh1ted/wdbgp)](https://hub.docker.com/r/wh1ted/wdbgp)
 ![Go](https://img.shields.io/badge/Go-1.26-00ADD8)
 ![Alpine](https://img.shields.io/badge/Alpine-3.23-0d597f)
@@ -11,7 +11,7 @@
 ![RouterOS](https://img.shields.io/badge/RouterOS-container-blue)
 ![Dual Stack](https://img.shields.io/badge/IP-IPv4%20%2B%20IPv6-blueviolet)
 ![Vue 3](https://img.shields.io/badge/Vue-3-4FC08D)
-![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6)
+![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6)
 
 [English version](README.md)
 


### PR DESCRIPTION
The Docker version badge in both READMEs tracked the `alpha` tag, which `deploy.yml` pushes only for prereleases (`type=raw,value=alpha,enable=...release.prerelease`). After 1.0.0 shipped, that tag stopped moving — Docker Hub still has `alpha` at 0.18.1-alpha (2026-07-30) while `latest`/`1.0.0` are from 2026-08-04, so the badge advertised a pre-1.0 alpha.

Switched it to the `latest` tag, which the same workflow pushes for non-prerelease releases, and relabelled it `docker`:

```
[[Docker Image Version](https://img.shields.io/docker/v/wh1ted/wdbgp/latest?label=docker)](https://hub.docker.com/r/wh1ted/wdbgp/tags)
```

Shields resolves a tagged `docker/v` badge through the tag's digest and displays the matching semver tag, so this renders `1.0.0` and keeps tracking stable releases without alphas moving it.

Also bumped the TypeScript badge from 5 to 6 — `webgui/package.json` is on `typescript ^6.0.3`. The remaining badges check out: Go 1.26 (`go.mod`, `golang:1.26.5-alpine3.23`), Alpine 3.23 (`Dockerfile`), Vue 3 (`vue ^3.4.34`).

Badge rendering was not verified visually — `img.shields.io` is blocked by the proxy in the session this was written in; the `1.0.0` claim rests on shields' documented digest-matching behaviour plus the live tag list from the Docker Hub API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eDnn5uePfz6DxqEQ4vXx2

---
_Generated by [Claude Code](https://claude.ai/code/session_019eDnn5uePfz6DxqEQ4vXx2)_